### PR TITLE
Use a pre-shared certificate for TLS

### DIFF
--- a/k8s/helm/templates/ingress.yaml
+++ b/k8s/helm/templates/ingress.yaml
@@ -8,18 +8,11 @@ metadata:
     helm.sh/chart: {{ include "chart.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    kubernetes.io/ingress.global-static-ip-name: launcher
+    ingress.gcp.kubernetes.io/pre-shared-cert: launcher
 spec:
   backend:
     serviceName: {{ .Chart.Name }}
     servicePort: 80
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
 {{- end }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -17,7 +17,3 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.global-static-ip-name: launcher
-  tls:
-    - secretName: tls-cert


### PR DESCRIPTION
As per https://github.com/ONSdigital/census-eq-terraform/pull/26 we want to use managed certificates for both dev and prod environments. This changes the helm configuration to always use a managed SSL certificate.