### PR TITLE
Allow launching census with survey / case_type / region_code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,42 +3,59 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:cf7759da55c9f1dfa3eefff1dbe140f0877d9081a0fa2d973a55595cbf11325c"
   name = "github.com/AreaHQ/jsonhal"
   packages = ["."]
+  pruneopts = ""
   revision = "715ffaec982bc9cb2636d5cadcd6def5f92fa49f"
 
 [[projects]]
+  digest = "1:141cc9fc6279592458b304038bd16a05ef477d125c6dad281216345a11746fd7"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "6b08a5c5172ba18946672b49749cde22873dd7c2"
+  version = "v3.2.0"
+
+[[projects]]
+  digest = "1:20ed7daa9b3b38b6d1d39b48ab3fd31122be5419461470d0c28de3e121c93ecf"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = ""
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:783fde5796ef54ba05de240f2529b6c9fbabc541e70ea43585c53b3f1bbabb5b"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = ""
   revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
   version = "v1.4.0"
 
 [[projects]]
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
-
-[[projects]]
+  digest = "1:8cce7ac3155e85d9054c69f804654e698002c2eae33b83c6b47d8615a4dd7838"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
     "json",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = ""
   revision = "b25e6cab129e4a54675b42ea49d38e9c33ade9e6"
   version = "v2.1.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "144248699bcf6581bf277d64d9a64247e26712ddba674ac8bf250a6cfd8b017d"
+  input-imports = [
+    "github.com/AreaHQ/jsonhal",
+    "github.com/gofrs/uuid",
+    "github.com/gorilla/mux",
+    "gopkg.in/square/go-jose.v2",
+    "gopkg.in/square/go-jose.v2/json",
+    "gopkg.in/square/go-jose.v2/jwt",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,8 +30,8 @@
   version = "1.4.0"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.1.0"
+  name = "github.com/gofrs/uuid"
+  version = "3.2.0"
 
 [[constraint]]
   name = "gopkg.in/square/go-jose.v2"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ docker run -it -p 8080:8080 onsdigital/eq-survey-register:simple-rest-api
 ```
 
 ### Run Quick-Launch
-For this to work ensure the JSON you are passing has an eq_id and form_type.
+If the schema specifies a `schema_name` field, that will be used as the schema_name claim. If not, the filename from the URL (before `.`) will be used.
+
 Run Survey Launcher
 ```
 scripts/run_app.sh

--- a/launch.go
+++ b/launch.go
@@ -5,29 +5,29 @@ import (
 
 	"html/template"
 	"log"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
-	"math/rand"
 
 	"html"
 
 	"github.com/ONSdigital/eq-questionnaire-launcher/authentication"
 	"github.com/ONSdigital/eq-questionnaire-launcher/settings"
 	"github.com/ONSdigital/eq-questionnaire-launcher/surveys"
+	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
-	"github.com/satori/go.uuid"
 	"gopkg.in/square/go-jose.v2/json"
 )
 
 func randomNumericString(n int) string {
-    var letter = []rune("0123456789")
+	var letter = []rune("0123456789")
 
-    output := make([]rune, n)
-    for i := range output {
-        output[i] = letter[rand.Intn(len(letter))]
-    }
-    return string(output)
+	output := make([]rune, n)
+	for i := range output {
+		output[i] = letter[rand.Intn(len(letter))]
+	}
+	return string(output)
 }
 
 func serveTemplate(templateName string, data interface{}, w http.ResponseWriter, r *http.Request) {
@@ -85,6 +85,8 @@ func postLaunchHandler(w http.ResponseWriter, r *http.Request) {
 
 func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	schema := r.URL.Query().Get("schema")
+	log.Println("Searching for schema: " + schema)
+
 	launcherSchema := surveys.FindSurveyByName(schema)
 
 	metadata, err := authentication.GetRequiredMetadata(launcherSchema)
@@ -143,13 +145,17 @@ func quickLauncherHandler(w http.ResponseWriter, r *http.Request) {
 	AccountServiceLogOutURL := getAccountServiceURL(r)
 	urlValues := r.URL.Query()
 	surveyURL := urlValues.Get("url")
+	defaultValues := authentication.GetDefaultValues()
 	log.Println("Quick launch request received", surveyURL)
 
-	urlValues.Add("ru_ref", authentication.GetDefaultValues()["ru_ref"])
-	urlValues.Add("collection_exercise_sid", uuid.NewV4().String())
-	urlValues.Add("case_id", uuid.NewV4().String())
+	urlValues.Add("ru_ref", defaultValues["ru_ref"])
+	collectionExerciseSid, _ := uuid.NewV4()
+	caseID, _ := uuid.NewV4()
+	urlValues.Add("collection_exercise_sid", collectionExerciseSid.String())
+	urlValues.Add("case_id", caseID.String())
 	urlValues.Add("questionnaire_id", randomNumericString(16))
 	urlValues.Add("response_id", randomNumericString(16))
+	urlValues.Add("language_code", defaultValues["language_code"])
 
 	token, err := authentication.GenerateTokenFromDefaults(surveyURL, accountServiceURL, AccountServiceLogOutURL, urlValues)
 	if err != "" {

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -3,23 +3,22 @@ package surveys
 import (
 	"encoding/json"
 	"log"
-		"regexp"
+	"regexp"
 
-	"github.com/AreaHQ/jsonhal"
-	"github.com/ONSdigital/eq-questionnaire-launcher/settings"
 	"fmt"
 	"io/ioutil"
-	"strings"
 	"sort"
+	"strings"
+
+	"github.com/AreaHQ/jsonhal"
 	"github.com/ONSdigital/eq-questionnaire-launcher/clients"
+	"github.com/ONSdigital/eq-questionnaire-launcher/settings"
 )
 
 // LauncherSchema is a representation of a schema in the Launcher
 type LauncherSchema struct {
-	Name     string
-	EqID     string
-	FormType string
-	URL      string
+	Name string
+	URL  string
 }
 
 // LauncherSchemas is a separation of Test and Live schemas
@@ -47,22 +46,10 @@ type Schema struct {
 
 var eqIDFormTypeRegex = regexp.MustCompile(`^(?P<eq_id>[a-z0-9]+)_(?P<form_type>\w+)`)
 
-func extractEqIDFormType(schema string) (EqID, formType string) {
-	match := eqIDFormTypeRegex.FindStringSubmatch(schema)
-	if match != nil {
-		EqID = match[1]
-		formType = match[2]
-	}
-	return
-}
-
 // LauncherSchemaFromFilename creates a LauncherSchema record from a schema filename
 func LauncherSchemaFromFilename(filename string) LauncherSchema {
-	EqID, formType := extractEqIDFormType(filename)
 	return LauncherSchema{
-		Name:     filename,
-		EqID:     EqID,
-		FormType: formType,
+		Name: filename,
 	}
 }
 
@@ -134,12 +121,9 @@ func getAvailableSchemasFromRegister() []LauncherSchema {
 
 		for _, schema := range schemas {
 			url := schema.Links["self"]
-			EqID, formType := extractEqIDFormType(schema.Name)
 			schemaList = append(schemaList, LauncherSchema{
-				Name:     schema.Name,
-				URL:      url.Href,
-				EqID:     EqID,
-				FormType: formType,
+				Name: schema.Name,
+				URL:  url.Href,
 			})
 		}
 	}

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -7,8 +7,8 @@
 <form action="" method="POST" xmlns="http://www.w3.org/1999/html">
 
     <div class="field-container">
-        <label for="schema">Schemas</label>
-        <select id="schema" name="schema" class="qa-select-schema" onchange="loadMetadata()">
+        <label for="schema_name">Schemas</label>
+        <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadata()">
             <option selected disabled>Select Schema</option>
             <optgroup label="Business Surveys">
                 {{range .Schemas.Business}}
@@ -38,6 +38,9 @@
         </select>
     </div>
 
+    <div id="census_claims">
+    </div>
+    
     <h3>Survey Metadata</h3>
     <div id="survey_metadata">
         <p>--- Metadata fields will be loaded when you select a schema ---</p>
@@ -107,7 +110,7 @@
             <option name="dumper" value="dumper" selected="selected">dumper</option>
         </select>
     </div>
-
+    
     <div class="field-container">
         <label for="account_service_url">Account Service URL</label>
         <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
@@ -119,8 +122,8 @@
     </div>
 
     <div class="field-container">
-        <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn" id="submit-btn" disabled="disabled" />
-        <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn" id="flush-btn" disabled="disabled" />
+        <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn" id="submit-btn" disabled="disabled"/>
+        <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn" id="flush-btn" disabled="disabled"/>
     </div>
 
 </form>
@@ -130,9 +133,53 @@
     // uuidv4: from https://github.com/kelektiv/node-uuid
     !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
+    const schema_name_census_regex = /^(census|ccs)_(household|individual|communal_establishment|communal_individual)_(gb_[a-z]{3})\s*$/
+    const case_types = {
+        'household': 'HH',
+        'individual': 'HI',
+        'communal_establishment': 'CE',
+        'communal_individual': 'CI'
+    }
+
+    function clearCensusClaims() {
+        document.getElementById('census_claims').innerHTML = ""
+    }
+
+    function includeCensusClaims() {
+        let schema_name = document.getElementById('schema_name').value
+        let matches = schema_name_census_regex.exec(schema_name)
+
+        let surveyValue = matches[1].toUpperCase()
+        let caseTypeValue = case_types[matches[2]]
+        let regionCodeValue = matches[3].toUpperCase().replace('_', '-')
+
+        var CensusClaimsHtml = "<div class=\"field-container\">" +
+                "<label for=\"survey\">Survey</label>" +
+                "<input id=\"survey\" name=\"survey\" type=\"text\" value=\"" + surveyValue + "\" class=\"qa-survey\">" +
+                "</div>" + 
+                "<div class=\"field-container\">" +
+                "<label for=\"case_type\">Case Type</label>" +
+                "<input id=\"case_type\" name=\"case_type\" type=\"text\" value=\"" + caseTypeValue + "\" class=\"qa-case_type\">" +
+                "</div>" + 
+                "<div class=\"field-container\">" +
+                "<label for=\"region_code\">Region Code</label>" +
+                "<input id=\"region_code\" name=\"region_code\" type=\"text\" value=\"" + regionCodeValue+ "\" class=\"qa-region_code\">" +
+                "</div>" 
+
+        document.getElementById('census_claims').innerHTML = CensusClaimsHtml
+    }
+
     function loadMetadata() {
         document.getElementById("submit-btn").disabled = true;
         document.getElementById("flush-btn").disabled = true;
+
+        let schema_name = document.getElementById("schema_name").value
+        if (schema_name.startsWith('census') || schema_name.startsWith('ccs')) {
+            includeCensusClaims()
+        } else {
+            clearCensusClaims()
+        }
+
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (this.readyState == 4) {
@@ -155,7 +202,7 @@
 
                             defaultValue = metadataField['default']
 
-                            var metadataFieldHtml = ""
+                            var metadataFieldHtml = "";
 
                             if (metadataField['type'] == "boolean") {
 
@@ -181,22 +228,21 @@
                                         "</div>"
                             }
 
-                            document.getElementById("survey_metadata").innerHTML = document.getElementById("survey_metadata").innerHTML + metadataFieldHtml
+                            document.getElementById("survey_metadata").innerHTML = document.getElementById("survey_metadata").innerHTML + metadataFieldHtml;
                         }
                     } else {
-                        document.getElementById("survey_metadata").innerHTML = "No metadata required for this survey"
+                        document.getElementById("survey_metadata").innerHTML = "No metadata required for this survey";
                     }
 
                     document.getElementById("submit-btn").disabled = false;
                     document.getElementById("flush-btn").disabled = false;
 
-
                 } else {
-                    document.getElementById("survey_metadata").innerHTML = "Failed to load Schema Metadata"
+                    document.getElementById("survey_metadata").innerHTML = "Failed to load Schema Metadata";
                 }
             }
         };
-        xhttp.open("GET", "/metadata?schema=" + document.getElementById('schema').value , true);
+        xhttp.open("GET", "/metadata?schema=" + document.getElementById('schema_name').value , true);
         xhttp.send();
     }
 


### PR DESCRIPTION
In combination with [runner PR](https://github.com/ONSdigital/eq-survey-runner/pull/2139).

Also uses schema_name instead of eq_id / form_type

Can be used to test changes being made in runner
around the census specific claims.

For any schemas starting with census / ccs, launcher will
convert the schema name into a survey / case_type / region_code

The UUID package being used was not maintained, and had a minor
version change with a breaking API change. I have switched to a
fork which is being maintained.

language_code now defaults to en on quick launch

### How to review
- Check that when a census schema is launched, the `survey` & `case_type` & `region_code` appear in the claims. Ensure schema_name does not.
- When launching a test schema, the schema_name should appear in the claims. The census claims should not.
- Check that quick-launch works with a schema having a file extension and no file extension
- Check that quick-launch works with a `schema_name` specified in the schema itself and a different filename.
- Ensure language_code defaults to 'en' on quick-launch.
- Make sure there are no references to eq_id and form_type left.