### PR TITLE
Add channel field to launcher metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ _testmain.go
 vendor/
 
 # binaries
-go-launch-a-survey
+eq-questionnaire-launcher

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -164,6 +164,10 @@
                 "<div class=\"field-container\">" +
                 "<label for=\"region_code\">Region Code</label>" +
                 "<input id=\"region_code\" name=\"region_code\" type=\"text\" value=\"" + regionCodeValue+ "\" class=\"qa-region_code\">" +
+                "</div>" +
+                "<div class=\"field-container\">" +
+                "<label for=\"channel\">Channel</label>" +
+                "<input id=\"channel\" name=\"channel\" type=\"text\" value=\"RH\" class=\"qa-channel\">" +
                 "</div>" 
 
         document.getElementById('census_claims').innerHTML = CensusClaimsHtml


### PR DESCRIPTION
To test the additional claim that will be added by RH and required downstream, channel has been added to the launcher page. Valid values are FIELD, RH, CC or AD only.

### To test
In order to test this, you will need to pull the _eq-2754-add-channel-to-submission_ branch of eq-survey-runner, which has the necessary changes to validate and submit the new claim downstream.

You can use the `/debug/submission` API endpoint to examine the JSON of what would be sent downstream.