### PR TITLE
Add NISRA languages

### DIFF
--- a/templates/launch.html
+++ b/templates/launch.html
@@ -97,8 +97,10 @@
     <div class="field-container">
         <label for="language_code">Language</label>
         <select id="language_code" name="language_code" class="qa-language-code">
-            <option name="en" value="en">en</option>
-            <option name="cy" value="cy">cy</option>
+            <option name="en" value="en">English (en)</option>
+            <option name="cy" value="cy">Cymraeg (cy)</option>
+            <option name="ga" value="ga">Gaeilge (ga)</option>
+            <option name="en_US" value="en_US">Ulstér Scotch (en_US)</option>
             <option name="" value="">&lt;not set&gt;</option>
         </select>
     </div>


### PR DESCRIPTION
Adds Gaeilge and Ulstér Scotch as launch languages for the NISRA Census surveys. 

`en_US` has been used for Ulstér Scotch as there is no language code in the CLDR (http://cldr.unicode.org) for it and this is required for survey runner to work.