### PR TITLE
Update the Ulster Scots language code

### DIFF
--- a/templates/launch.html
+++ b/templates/launch.html
@@ -100,7 +100,7 @@
             <option name="en" value="en">English (en)</option>
             <option name="cy" value="cy">Cymraeg (cy)</option>
             <option name="ga" value="ga">Gaeilge (ga)</option>
-            <option name="en_US" value="en_US">Ulstér Scotch (en_US)</option>
+            <option name="eo" value="eo">Ulstér Scotch (eo)</option>
             <option name="" value="">&lt;not set&gt;</option>
         </select>
     </div>


### PR DESCRIPTION
Updating the launcher html code so that it uses the new language code that has been chosen for Ulster Scots - 'eo'.