### PR TITLE
CCS schema branch

### DIFF
--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -183,17 +183,17 @@ func FindSurveyByName(name string) LauncherSchema {
 			return survey
 		}
 	}
+	for _, survey := range availableSchemas.CCS {
+		if survey.Name == name {
+			return survey
+		}
+	}
 	for _, survey := range availableSchemas.Census {
 		if survey.Name == name {
 			return survey
 		}
 	}
 	for _, survey := range availableSchemas.Social {
-		if survey.Name == name {
-			return survey
-		}
-	}
-	for _, survey := range availableSchemas.Test {
 		if survey.Name == name {
 			return survey
 		}

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -24,6 +24,7 @@ type LauncherSchema struct {
 // LauncherSchemas is a separation of Test and Live schemas
 type LauncherSchemas struct {
 	Business []LauncherSchema
+	CCS      []LauncherSchema
 	Census   []LauncherSchema
 	Social   []LauncherSchema
 	Test     []LauncherSchema
@@ -66,6 +67,8 @@ func GetAvailableSchemas() LauncherSchemas {
 			schemaList.Census = append(schemaList.Census, launcherSchema)
 		} else if strings.HasPrefix(launcherSchema.Name, "lms_") {
 			schemaList.Social = append(schemaList.Social, launcherSchema)
+		} else if strings.HasPrefix(launcherSchema.Name, "ccs_") {
+			schemaList.CCS = append(schemaList.CCS, launcherSchema)
 		} else {
 			schemaList.Business = append(schemaList.Business, launcherSchema)
 		}
@@ -77,6 +80,7 @@ func GetAvailableSchemas() LauncherSchemas {
 	sort.Sort(ByFilename(schemaList.Census))
 	sort.Sort(ByFilename(schemaList.Social))
 	sort.Sort(ByFilename(schemaList.Test))
+	sort.Sort(ByFilename(schemaList.CCS))
 
 	return schemaList
 }
@@ -185,6 +189,11 @@ func FindSurveyByName(name string) LauncherSchema {
 		}
 	}
 	for _, survey := range availableSchemas.Social {
+		if survey.Name == name {
+			return survey
+		}
+	}
+	for _, survey := range availableSchemas.Test {
 		if survey.Name == name {
 			return survey
 		}

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -15,6 +15,11 @@
                     <option name="{{.Name}}" value="{{.Name}}">{{.Name}}</option>
                 {{end}}
             </optgroup>
+            <optgroup label="CCS Surveys">
+                {{range .Schemas.CCS}}
+                    <option name="{{.Name}}" value="{{.Name}}">{{.Name}}</option>
+                {{end}}
+            </optgroup>
             <optgroup label="Census Surveys">
                 {{range .Schemas.Census}}
                     <option name="{{.Name}}" value="{{.Name}}">{{.Name}}</option>


### PR DESCRIPTION
### What is the context of this PR?
CCS schemas had to be removed from Business to its own branch in launcher. Moving it to CCS branch is not best possible solution(it is in fact Census schema) but the way schemas are created in runner's "make build schemas" script, "census_ccs" or "census_cs" combinations are not allowed. 
### How to review
Make sure that port 8000 is not being used. Install Go as described in README file and run launcher using it, start runner and supporting services, then check if you can start CCS schemas from launcher's menu and it's on a correct branch.