### PR TITLE
Don’t add empty claims to the token

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -136,7 +136,9 @@ func generateClaims(claimValues map[string][]string, launcherSchema surveys.Laun
 
 	for key, value := range claimValues {
 		if key != "roles" {
-			claims[key] = value[0]
+			if value[0] != "" {
+				claims[key] = value[0]
+			}
 		} else {
 			claims[key] = value
 		}


### PR DESCRIPTION
Fixes issue where empty claims in the token break runner, for example account_service_url fails when an empty string as if present it must be a url.