### PR TITLE
Upgrade to Helm 3 + Use app deploy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run -it -p 8080:8080 onsdigital/eq-survey-register:simple-rest-api
 ### Run Quick-Launch
 If the schema specifies a `schema_name` field, that will be used as the schema_name claim. If not, the filename from the URL (before `.`) will be used.
 
-Run Survey Launcher
+Run Questionnaire Launcher
 ```
 scripts/run_app.sh
 ```

--- a/ci/README.md
+++ b/ci/README.md
@@ -14,7 +14,7 @@ The following are optional variables that can also be set if needed:
 - REGION
 - IMAGE_TAG
 
-To deploy to a cluster you can run the following command
+	To deploy the app to the cluster via Concourse, use the following task command, specifying the `image_registry` and the `build_image_version` variables:
 
 ```sh
 PROJECT_ID=<project_id> \
@@ -22,4 +22,6 @@ DOCKER_REGISTRY=<docker_registry> \
 RUNNER_URL=<runner_instance_url> \
 fly -t <target_concourse_instance> execute \
   --config ci/deploy.yaml
+  -v image_registry=<docker-registry> \
+  -v build_image_version=<image-tag>
 ```

--- a/ci/README.md
+++ b/ci/README.md
@@ -14,7 +14,7 @@ The following are optional variables that can also be set if needed:
 - REGION
 - IMAGE_TAG
 
-	To deploy the app to the cluster via Concourse, use the following task command, specifying the `image_registry` and the `build_image_version` variables:
+	To deploy the app to the cluster via Concourse, use the following task command, specifying the `image_registry` and the `deploy_image_version` variables:
 
 ```sh
 PROJECT_ID=<project_id> \
@@ -23,5 +23,5 @@ RUNNER_URL=<runner_instance_url> \
 fly -t <target_concourse_instance> execute \
   --config ci/deploy.yaml
   -v image_registry=<docker-registry> \
-  -v build_image_version=<image-tag>
+  -v deploy_image_version=<image-tag>
 ```

--- a/ci/deploy.yaml
+++ b/ci/deploy.yaml
@@ -11,7 +11,6 @@ params:
   DOCKER_REGISTRY:
   IMAGE_TAG: latest
   RUNNER_URL:
-
 inputs:
   - name: eq-questionnaire-launcher
 run:

--- a/ci/deploy.yaml
+++ b/ci/deploy.yaml
@@ -3,7 +3,7 @@ image_resource:
   type: docker-image
   source:
     repository: ((image_registry))/eq-app-deploy-image
-    tag: ((build_image_version))
+    tag: ((deploy_image_version))
 params:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
   PROJECT_ID:

--- a/ci/deploy.yaml
+++ b/ci/deploy.yaml
@@ -2,7 +2,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: theorf/google-cloud-sdk-helm
+    repository: ((image_registry))/eq-app-deploy-image
+    tag: ((build_image_version))
 params:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
   PROJECT_ID:
@@ -10,6 +11,7 @@ params:
   DOCKER_REGISTRY:
   IMAGE_TAG: latest
   RUNNER_URL:
+
 inputs:
   - name: eq-questionnaire-launcher
 run:
@@ -17,8 +19,6 @@ run:
   args:
     - -exc
     - |
-      apt-get install -y procps
-
       export GOOGLE_APPLICATION_CREDENTIALS=/root/gcloud-service-key.json
       cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
       $SERVICE_ACCOUNT_JSON
@@ -26,9 +26,6 @@ run:
 
       gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud container clusters get-credentials survey-runner --region ${REGION} --project ${PROJECT_ID}
-
-      helm init --client-only
-      helm plugin install https://github.com/rimusz/helm-tiller
 
       cd eq-questionnaire-launcher
       ./k8s/deploy_app.sh

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -7,3 +7,6 @@ helm upgrade --install \
     --set surveyRunnerUrl=https://${RUNNER_URL} \
     --set image.repository=${DOCKER_REGISTRY}/eq-questionnaire-launcher \
     --set image.tag=${IMAGE_TAG}
+
+kubectl rollout restart deployment.v1.apps/launcher
+kubectl rollout status deployment.v1.apps/launcher

--- a/k8s/deploy_app.sh
+++ b/k8s/deploy_app.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-helm tiller run \
-    helm upgrade --install \
-    survey-launcher \
+helm upgrade --install \
+    questionnaire-launcher \
     k8s/helm \
     --set surveyRunnerUrl=https://${RUNNER_URL} \
     --set image.repository=${DOCKER_REGISTRY}/eq-questionnaire-launcher \

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -1,5 +1,4 @@
-apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart for deploying Survey Launcher to Kubernetes
+apiVersion: v2
+description: A Helm chart for deploying Questionnaire Launcher to Kubernetes
 name: launcher
-version: 0.1.0
+version: 1.0.0

--- a/k8s/helm/templates/NOTES.txt
+++ b/k8s/helm/templates/NOTES.txt
@@ -1,1 +1,1 @@
-Survey Launcher Application deployed.
+Questionnaire Launcher Application deployed.


### PR DESCRIPTION
### What is the context of this PR?
- Upgrades launcher to support Helm 3.
- Specify the app deploy image and version when deploying with CI.

### How to review 
- Deploy a cluster using: https://github.com/ONSdigital/census-eq-terraform or Concourse.
- Use the `ci/README.md` to deploy the application to the cluster. Ensure the instructions are clear. 
**IMPORTANT NOTE**: If you are using an existing cluster with any deployments of launcher made by Helm 2, you must use Helm 2 to delete the launcher release before deploying with Helm 3. This is because Helm 3 cannot see the releases made by Helm 2 however, you cannot apply on top due to conflicts.

	To delete the release with Helm 2:
	1. Log in to the cluster _(You may need to add your IP to the cluster)_:
`gcloud container clusters get-credentials survey-runner --region europe-west2 --project <project_id>`
	2. Run: `helm init --client-only`
	3. Run: `helm tiller run helm delete survey-launcher --purge`
	4. Verify there are no releases using: `helm tiller run helm ls`
	5. Additionally, you can check that secrets stored by Helm 2 are also deleted: 
		`kubectl get secret --namespace kube-system  | grep 'survey-launcher'`
	6. Helm 3 secrets are stored in the `default` namespace with the scheme:
		`sh.helm.release.v1.<release_name>.v<revision_version>.`

- Use must now specify the `image_registry` and the `deploy_image_version` variables when using the task yaml to fly execute.
	
	For testing, you can use:
	```yaml
	image_registry: 'eu.gcr.io/census-eq-ci'
	deploy_image_version: 'latest'
	```
- Ensure you can still deploy runner credentials as expected.

**If you want to make things easier, use Concourse to test all of this using:**
	- https://github.com/ONSdigital/census-eq-concourse/pull/53