### PR TITLE
Handle index error when accessing schema name

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -143,7 +143,7 @@ func generateClaims(claimValues map[string][]string, launcherSchema surveys.Laun
 			claims[key] = value
 		}
 	}
-    var isCensusTestSchema = claimValues["schema_name"][0] == "test_individual_response"
+    var isCensusTestSchema = len(claimValues["schema_name"]) > 0 && claimValues["schema_name"][0] == "test_individual_response"
 	if !isCensusTestSchema && (len(claimValues["survey"]) > 0 || len(claimValues["form_type"]) > 0 || len(claimValues["region_code"]) > 0) {
 		log.Println("Deleting schema name from claims")
 		delete(claims, "schema_name")


### PR DESCRIPTION
### What is the context of this PR?
Avoids index error when schema name does not exist in the claims.

### How to review 
Are you able to successfully quick launch a census schema?

If you use docker, update the image tag to: 
```        
image: "onsdigital/eq-questionnaire-launcher:handle-index-error-when-check-schema-name"
```