### PR TITLE
Add nodeSelector and tolerations to Kubernetes pods

### DIFF
--- a/k8s/helm/templates/deployment.yaml
+++ b/k8s/helm/templates/deployment.yaml
@@ -24,6 +24,13 @@ spec:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      nodeSelector:
+        node-pool-name: {{ .Values.targetNodePool }}
+      tolerations:
+        - key: "node-pool-name"
+          operator: "Equal"
+          value: {{ .Values.targetNodePool }}
+          effect: "NoExecute"
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -17,3 +17,5 @@ service:
 
 ingress:
   enabled: true
+
+targetNodePool: "main-node-pool"


### PR DESCRIPTION
### What is the context of this PR?
We now provision 2 node pools, 1 for the application and 1 for cluster level pods such as the `metrics-server`. This PR adds a `nodeSelector` so that the pod knows which node it must deploy to. The application node pool has a `taint` set so that other cluster level pods are rejected, but this mean a `toleration` need to be added to the application pod so that it can still be scheduled on our application node pool.

### How to review
Ensure:
- the pod is only deployed to a node pool with a matching `nodeSelector`. 
- at least 1 node pool's taint matches the `tolerations` specified on the pod.
- the application work as expected

Review using https://github.com/ONSdigital/eq-pipelines/pull/148