### PR TITLE
Push to GCR on PRs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -21,10 +21,8 @@ jobs:
           docker push onsdigital/eq-questionnaire-launcher:latest
       - name: Push to GCR
         env:
-          DOCKER_BUILDKIT: 1
-          GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
-          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         run: |
-          echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing with tag [latest]"
           docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: >
-          docker build -t onsdigital/eq-questionnaire-launcher:latest .
+          docker build -t onsdigital/eq-questionnaire-launcher:latest
           -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
       - name: Push to Docker Hub
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,3 +17,18 @@ jobs:
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [latest]"
           docker push onsdigital/eq-questionnaire-launcher:latest
+  gcr-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: >
+          docker build -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
+      - name: Push
+        env:
+          DOCKER_BUILDKIT: 1
+          GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+        run: |
+          echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Build
         run: >
           docker build -t onsdigital/eq-questionnaire-launcher:latest
-          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
+          -t eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:latest .
       - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -25,4 +25,4 @@ jobs:
         run: |
           echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing with tag [latest]"
-          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest
+          docker push eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,18 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: >
-          docker build -t onsdigital/eq-questionnaire-launcher:latest
-          -t eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:latest .
-      - name: Push to Docker Hub
+        run: docker build -t onsdigital/eq-questionnaire-launcher:latest .
+      - name: Push
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [latest]"
           docker push onsdigital/eq-questionnaire-launcher:latest
-      - name: Push to GCR
-        env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        run: |
-          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
-          echo "Pushing with tag [latest]"
-          docker push eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: docker build -t onsdigital/eq-questionnaire-launcher:latest .
-      - name: Push to Docker Hub
+      - name: Push
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [latest]"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,24 +11,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: docker build -t onsdigital/eq-questionnaire-launcher:latest .
-      - name: Push
+        run: >
+          docker build -t onsdigital/eq-questionnaire-launcher:latest .
+          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
+      - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [latest]"
           docker push onsdigital/eq-questionnaire-launcher:latest
-  gcr-push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: >
-          docker build -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
-      - name: Push
+      - name: Push to GCR
         env:
           DOCKER_BUILDKIT: 1
           GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
           PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
         run: |
           echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo "Pushing with tag [latest]"
           docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,17 +12,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: >
-          docker build -t onsdigital/eq-questionnaire-launcher:latest
-          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
+          docker build -t onsdigital/eq-questionnaire-launcher:latest .
       - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [latest]"
           docker push onsdigital/eq-questionnaire-launcher:latest
-      - name: Push to GCR
-        env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
-        run: |
-          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
-          echo "Pushing with tag [latest]"
-          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: >
-          docker build -t onsdigital/eq-questionnaire-launcher:latest .
+        run: docker build -t onsdigital/eq-questionnaire-launcher:latest .
       - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,9 +11,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: docker build -t onsdigital/eq-questionnaire-launcher:latest .
-      - name: Push
+        run: >
+          docker build -t onsdigital/eq-questionnaire-launcher:latest
+          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest .
+      - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [latest]"
           docker push onsdigital/eq-questionnaire-launcher:latest
+      - name: Push to GCR
+        env:
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+        run: |
+          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo "Pushing with tag [latest]"
+          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,8 +43,8 @@ jobs:
           docker push onsdigital/eq-questionnaire-launcher:$TAG
       - name: Push to GCR
         env:
-          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          GCR_SERVICE_KEY: ${{ secrets.GCR_SERVICE_KEY }}
         run: |
-          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo $GCR_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing with tag [$TAG]"
           docker push eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,3 +39,22 @@ jobs:
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [$TAG]"
           docker push onsdigital/eq-questionnaire-launcher:$TAG
+  gcr-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag
+        run: |
+          CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
+          echo "TAG=$CLEAN_TAG" >> $GITHUB_ENV
+      - name: Build
+        run: >
+          docker build -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG .
+      - name: Push
+        env:
+          DOCKER_BUILDKIT: 1
+          GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+        run: |
+          echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,28 +33,20 @@ jobs:
       - name: Tag
         run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
       - name: Build
-        run: docker build -t onsdigital/eq-questionnaire-launcher:$TAG .
-      - name: Push
+        run: >
+          docker build -t onsdigital/eq-questionnaire-launcher:$TAG .
+          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG .
+      - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           echo "Pushing with tag [$TAG]"
           docker push onsdigital/eq-questionnaire-launcher:$TAG
-  gcr-push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Tag
-        run: |
-          CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
-          echo "TAG=$CLEAN_TAG" >> $GITHUB_ENV
-      - name: Build
-        run: >
-          docker build -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG .
-      - name: Push
+      - name: Push to GCR
         env:
           DOCKER_BUILDKIT: 1
           GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
           PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
         run: |
           echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo "Pushing with tag [$TAG]"
           docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,10 +43,8 @@ jobs:
           docker push onsdigital/eq-questionnaire-launcher:$TAG
       - name: Push to GCR
         env:
-          DOCKER_BUILDKIT: 1
-          GCLOUD_SERVICE_JSON: ${{ secrets.GCLOUD_SERVICE_KEY }}
-          PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCLOUD_SERVICE_KEY }}
         run: |
-          echo $GCLOUD_SERVICE_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing with tag [$TAG]"
           docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: >
           docker build -t onsdigital/eq-questionnaire-launcher:$TAG
-          -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG .
+          -t eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:$TAG .
       - name: Push to Docker Hub
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -47,4 +47,4 @@ jobs:
         run: |
           echo $GCLOUD_SERVICE_KEY | docker login -u _json_key --password-stdin https://eu.gcr.io
           echo "Pushing with tag [$TAG]"
-          docker push eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG
+          docker push eu.gcr.io/${{ secrets.GCR_PROJECT_ID }}/eq-questionnaire-launcher:$TAG

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
       - name: Build
         run: >
-          docker build -t onsdigital/eq-questionnaire-launcher:$TAG .
+          docker build -t onsdigital/eq-questionnaire-launcher:$TAG
           -t eu.gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/eq-questionnaire-launcher:$TAG .
       - name: Push to Docker Hub
         run: |


### PR DESCRIPTION
### What is the context of this PR?
This adds new `Push to GCR` task to both `pull-request` and `master` workflows. New service account with `Storage Legacy Bucket Reader`(storage.buckets.get, storage.objects.list, storage.multipartUploads.list) and `Storage Object Admin` roles was created in the gcp project. This change requires two new secrets to be added to the repository: `GCLOUD_SERVICE_KEY` and `GCLOUD_PROJECT_ID`. This has been tested in [this fork of launcher](https://github.com/petechd/eq-questionnaire-launcher/pulls). Container Registry with pushed images can be found [here](https://console.cloud.google.com/gcr/images/pete-test-env-on-release).
EDIT: Runner and Launcher PRs are now pushing images tagged with branch name to our dev repository too.

### How to review 
- Fork the repository 
- in gcp (your project) create new service account with `Storage Legacy Bucket Reader` and `Storage Object Admin` roles
- add service account's json key as `GCLOUD_SERVICE_KEY` and your gcp project name as `GCLOUD_PROJECT_ID` to your forked repo secrets
-  create some pull requests or make some changes to master of your forked repository