### PR TITLE
Get image tag from deploy_app task inputs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -5,6 +5,7 @@ To deploy this application with Concourse, you must be logged in to a Concourse 
 ---
 
 Make sure the required [environment variables](../README.md#environment-variables) are set.
+IMAGE_TAG can be passed as an environment variable or as a file input located at `./image-tag/tag`.
 
 To deploy the app via Concourse, use the following task command:
 

--- a/ci/deploy.yaml
+++ b/ci/deploy.yaml
@@ -15,6 +15,8 @@ params:
   MAX_INSTANCES:
 inputs:
   - name: eq-questionnaire-launcher
+  - name: image-tag
+    optional: true
 run:
   path: bash
   args:

--- a/ci/deploy.yaml
+++ b/ci/deploy.yaml
@@ -26,6 +26,9 @@ run:
       EOL
 
       gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-
+      FILE=./image-tag/tag
+      if [[ -f "${FILE}" ]]; then
+        export IMAGE_TAG=`cat "$FILE"`
+      fi
       cd eq-questionnaire-launcher
       ./ci/deploy_app.sh


### PR DESCRIPTION
### What is the context of this PR?
This is complementary PR for the eq-pipelines changes in [this PR](https://github.com/ONSdigital/eq-pipelines/pull/247).

### How to review 
Fly your pipeline using image of the app in this PR or check [my pipeline where I used these settings](https://concourse.gcp.onsdigital.uk/teams/eq/pipelines/pete-test-env-on-release).