### PR TITLE
Adds launcher parameters for adding JWT claim `response_expires_at`

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -2,6 +2,7 @@ package main // import "github.com/ONSdigital/eq-questionnaire-launcher"
 
 import (
 	"fmt"
+	"time"
 
 	"html/template"
 	"log"
@@ -155,6 +156,7 @@ func quickLauncherHandler(w http.ResponseWriter, r *http.Request) {
 	urlValues.Add("case_id", caseID.String())
 	urlValues.Add("response_id", randomNumericString(16))
 	urlValues.Add("language_code", defaultValues["language_code"])
+	urlValues.Add("response_expires_at", time.Now().AddDate(0, 0, 7).Format("2006-01-02T15:04:05+00:00"))
 
 	token, err := authentication.GenerateTokenFromDefaults(surveyURL, accountServiceURL, AccountServiceLogOutURL, urlValues)
 	if err != "" {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -255,7 +255,7 @@
     function setResponseExpiry(days_offset=7) {
         var dt = new Date();
         dt.setDate(dt.getDate()+days_offset)
-        document.getElementById('response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '');
+        document.getElementById('response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
     }
 
     function validateForm() {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -259,6 +259,10 @@
     }
 
     function validateForm() {
+        validateResponseExpiresAt();
+    }
+
+    function validateResponseExpiresAt() {
         response_expires_at = Date.parse(document.getElementById('response_expires_at').value)
         if (isNaN(response_expires_at)) {
             document.getElementById('response_expires_at').remove()

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -4,7 +4,7 @@
 <h1>Launch a survey</h1>
 <div class="field-wrap">
 
-<form action="" method="POST" xmlns="http://www.w3.org/1999/html">
+<form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
 
     <div class="field-container">
         <label for="schema_name">Schemas</label>
@@ -74,6 +74,15 @@
             <img onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
         </span>
     </div>
+
+    <div class="field-container">
+        <label for="response_expires_at">Response Expiry Time</label>
+        <span>
+            <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
+            <img onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+        </span>
+    </div>
+
 
     <h3>Runner Data</h3>
     <div class="field-container">
@@ -243,10 +252,24 @@
         document.getElementById(el_id).value = result;
     }
 
+    function setResponseExpiry(days_offset=7) {
+        var dt = new Date();
+        dt.setDate(dt.getDate()+days_offset)
+        document.getElementById('response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '');
+    }
+
+    function validateForm() {
+        response_expires_at = Date.parse(document.getElementById('response_expires_at').value)
+        if (isNaN(response_expires_at)) {
+            document.getElementById('response_expires_at').remove()
+        }
+    }
+
     uuid('collection_exercise_sid');
     uuid('case_id');
     ruref('ru_ref');
     numericId('response_id');
+    setResponseExpiry();
 
 </script>
 


### PR DESCRIPTION
### What is the context of this PR?
Adds a field in launcher to autogenerate a `response_expires_at` key for the JWT claim. If it is invalid or non existent it is omitted from the claims. 

See also https://github.com/ONSdigital/eq-questionnaire-runner/pull/715

### How to review 
Run launcher and see that the correct date (7 days from now as default) is present.
