### PR TITLE
Fix bug when using numerical eQ ID

### DIFF
--- a/templates/launch.html
+++ b/templates/launch.html
@@ -145,7 +145,7 @@
         document.querySelector("#flush-btn").disabled = true;
 
         const schema_name = document.querySelector("#schema_name").value
-        const survey_type = document.querySelector(`#schema_name option[value=${schema_name}]`).dataset.surveyType
+        const survey_type = document.querySelector(`#schema_name option[value="${schema_name}"]`).dataset.surveyType
 
         if (survey_type.toLowerCase() === "test") {
             clearSurveyMetadataFields()


### PR DESCRIPTION
### What is the context of this PR?
Fixes a bug in which launcher cannot get the survey type for questionnaires that have a numerical eq id.

### How to review 
Ensure you can select and launch a questionnaire with a numerical eq id, such as the [QBS](https://github.com/ONSdigital/eq-questionnaire-runner/pull/795) one that was just delivered. 