### PR TITLE
Rename survey-url to schema-url

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -261,7 +261,7 @@ func getSchemaClaims(LauncherSchema surveys.LauncherSchema) map[string]interface
 
 	schemaClaims := make(map[string]interface{})
 	if LauncherSchema.URL != "" {
-		schemaClaims["survey_url"] = LauncherSchema.URL
+		schemaClaims["schema_url"] = LauncherSchema.URL
 	}
 
 	return schemaClaims


### PR DESCRIPTION
### What is the context of this PR?
Renames instances of `survey-url` to `schema-url`

### How to review 
Test launching a schema with a `schema-url`
