### PR TITLE
Ability to specify schema URL

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -405,9 +405,10 @@ func TransformSchemaParamsToName(postValues url.Values) string {
 func GenerateTokenFromPost(postValues url.Values) (string, string) {
 	log.Println("POST received: ", postValues)
 
-	schema := TransformSchemaParamsToName(postValues)
+	schemaName := TransformSchemaParamsToName(postValues)
+	schemaUrl := postValues.Get("survey_url")
 
-	launcherSchema := surveys.FindSurveyByName(schema)
+	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl)
 
 	claims := generateClaims(postValues, launcherSchema)
 

--- a/launch.go
+++ b/launch.go
@@ -85,10 +85,10 @@ func postLaunchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
-	schema := r.URL.Query().Get("schema")
-	log.Println("Searching for schema: " + schema)
+	schemaName := r.URL.Query().Get("schema_name")
+	schemaUrl := r.URL.Query().Get("schema_url")
 
-	launcherSchema := surveys.FindSurveyByName(schema)
+	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl)
 
 	metadata, err := authentication.GetRequiredMetadata(launcherSchema)
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -84,6 +84,11 @@ select[multiple] {
     margin: 0.5rem;
 }
 
+.btn:disabled {
+    background: #cccccc;
+    color: grey;
+}
+
 #schema-url-name {
     display: none;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -20,6 +20,23 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
     position: relative;
 }
 
+#schema-url-btn {
+    vertical-align: middle;
+    background:#6099c6;
+    color:white;
+    border-radius:3px;
+    display:inline-block;
+    text-align: center;
+    font-size: 0.9rem;
+    padding:0.50rem 2rem;
+    margin: 0.1rem;
+}
+
+#schema-url-btn:disabled {
+    background: #cccccc;
+    color: grey;
+}
+
 input[type=text] {
     padding:0.3rem;
     width:350px;
@@ -60,10 +77,13 @@ select[multiple] {
     color:white;
     border:0;
     border-radius:3px;
-    display:block;
+    display:inline-block;
     padding:0.75rem 2rem;
     text-align: center;
     font-size: 1rem;
     margin: 0.5rem;
-    float: left;
+}
+
+#schema-url-name {
+    display: none;
 }

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -171,3 +171,24 @@ func FindSurveyByName(name string) LauncherSchema {
 
 	panic("Schema not found")
 }
+
+// Return a LauncherSchema instance by loading schema from name or URL
+func GetLauncherSchema(schemaName string, schemaUrl string) LauncherSchema {
+    var launcherSchema LauncherSchema
+
+    if schemaUrl != "" {
+        log.Println("Getting schema by URL: " + schemaUrl)
+        launcherSchema = LauncherSchema {
+            URL: schemaUrl,
+            Name: schemaName,
+        }
+    } else if schemaName != "" {
+        log.Println("Searching for schema by name: " + schemaName)
+        launcherSchema = FindSurveyByName(schemaName)
+    } else {
+        panic("Either `schema_name` or `schema_url` must be provided.")
+    }
+
+    return launcherSchema
+}
+

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -25,6 +25,7 @@
     <p>----------</p>
 
     <strong><u>Launch by Schema URL</u></strong>
+
     <div class="field-container">
         <span>
             <label for="schema-url-survey-type">Survey Type</label>
@@ -41,7 +42,6 @@
         <span>
             <label for="schema-url">Schema URL</label>
             <input id="schema-url" name="survey_url" type="text" class="qa-schema_url">
-            <input type="submit" onClick="return loadMetadataForSchemaUrl()" value="Load Schema" class="qa-btn-submit-dev btn" id="schema-url-btn"/>
         </span>
     </div>
 
@@ -50,6 +50,10 @@
             <label for="schema-url-name-input">Schema Name</label>
             <input id="schema-url-name-input" name="schema_name" type="text" class="qa-schema_url_name" disabled>
         </span>
+    </div>
+
+    <div class="field-container">
+        <input type="submit" onClick="return loadMetadataForSchemaUrl()" value="Load Schema" class="qa-btn-submit-dev btn" id="schema-url-btn"/>
     </div>
 
     <p>----------</p>

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -178,6 +178,8 @@
     }
 
     function clearAndDisableSchemaUrlSelection() {
+        document.querySelector("#schema-url-btn").disabled = true;
+
         let schemaUrlElement = document.querySelector("#schema-url")
         let surveyTypeElement = document.querySelector("#schema-url-survey-type")
 
@@ -205,11 +207,6 @@
     }
 
     function loadMetadataForSchemaUrl() {
-        if (document.querySelector("#schema_name").selectedIndex !== 0) {
-            document.querySelector("#schema-url-btn").disabled = true;
-            return false
-        }
-
         let schemaUrl = document.querySelector("#schema-url").value
         if (!schemaUrl || !schemaUrl.endsWith(".json")) {
             alert("Schema URL not provided or is not valid.\n" +

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -214,7 +214,7 @@
         }
 
         let surveyType = document.querySelector("#schema-url-survey-type").value
-        if (surveyType === "Select Survey Type") {
+        if (surveyType.toLowerCase() === "select survey type") {
             alert("Select a Survey Type.")
             return false
         }
@@ -226,7 +226,7 @@
         loadSurveyMetadata(schemaName, surveyType)
         loadSchemaMetadata(schemaName, schemaUrl)
 
-        if (surveyType === "test") {
+        if (surveyType.toLowerCase() === "test") {
             let schemaUrlNameInput = document.querySelector("#schema-url-name-input")
             schemaUrlNameInput.value = schemaName
             schemaUrlNameInput.disabled = false

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -6,9 +6,10 @@
 
 <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
 
+    <strong><u>Launch by Schema Name</u></strong>
     <div class="field-container">
         <label for="schema_name">Schemas</label>
-        <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadata()">
+        <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName()">
             <option selected disabled>Select Schema</option>
 
             {{ range $surveyType, $schemasList := .Schemas }}
@@ -21,12 +22,44 @@
         </select>
     </div>
 
+    <p>----------</p>
+
+    <strong><u>Launch by Schema URL</u></strong>
+    <div class="field-container">
+        <span>
+            <label for="schema-url-survey-type">Survey Type</label>
+            <select name="survey-types" id="schema-url-survey-type">
+                <option selected disabled>Select Survey Type</option>
+                {{ range $surveyType, $schemasList := .Schemas }}
+                <option name="{{ $surveyType }}" value="{{ $surveyType }}" data-schema-url-survey-type="{{ $surveyType }}">{{ $surveyType }}</option>
+            {{ end }}
+            </select>
+        </span>
+    </div>
+
+    <div class="field-container">
+        <span>
+            <label for="schema-url">Schema URL</label>
+            <input id="schema-url" name="survey_url" type="text" class="qa-schema_url">
+            <input type="submit" onClick="return loadMetadataForSchemaUrl()" value="Load Schema" class="qa-btn-submit-dev btn" id="schema-url-btn"/>
+        </span>
+    </div>
+
+    <div class="field-container" id="schema-url-name">
+        <span>
+            <label for="schema-url-name-input">Schema Name</label>
+            <input id="schema-url-name-input" name="schema_name" type="text" class="qa-schema_url_name" disabled>
+        </span>
+    </div>
+
+    <p>----------</p>
+
     <div id="survey_metadata_fields">
     </div>
 
     <h3>Survey Metadata</h3>
     <div id="survey_metadata">
-        <p>--- Metadata fields will be loaded when you select a schema ---</p>
+        <p>--- Metadata fields will be loaded when you select or load a schema ---</p>
     </div>
 
     <h3>Required Data</h3>
@@ -125,7 +158,7 @@
 
     function includeSurveyMetadataFields(schema_name, survey_type) {
         let eqIdValue = schema_name.split('_')[0]
-        let formTypeValue = schema_name.split('_')[1]
+        let formTypeValue = schema_name.split("_").slice(1).join("_")
 
         document.querySelector('#survey_metadata_fields').innerHTML = `
             <h3>${survey_type} Survey Metadata</h3>
@@ -140,19 +173,81 @@
         `
     }
 
-    function loadMetadata() {
+    function clearAndDisableSchemaUrlSelection() {
+        let schemaUrlElement = document.querySelector("#schema-url")
+        let surveyTypeElement = document.querySelector("#schema-url-survey-type")
+
+        surveyTypeElement.selectedIndex = 0
+        schemaUrlElement.value = ""
+        surveyTypeElement.disabled = true
+        schemaUrlElement.disabled = true
+    }
+
+    function clearAndDisableSchemaNameSelection() {
+        let schemaNameElement = document.querySelector("#schema_name")
+
+        schemaNameElement.selectedIndex = 0
+        schemaNameElement.disabled = true
+    }
+
+    function loadMetadataForSchemaName() {
+        clearAndDisableSchemaUrlSelection()
+
+        const schemaName = document.querySelector("#schema_name").value
+        const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
+
+        loadSurveyMetadata(schemaName, surveyType)
+        loadSchemaMetadata(schemaName, null)
+    }
+
+    function loadMetadataForSchemaUrl() {
+        if (document.querySelector("#schema_name").selectedIndex !== 0) {
+            document.querySelector("#schema-url-btn").disabled = true;
+            return false
+        }
+
+        let schemaUrl = document.querySelector("#schema-url").value
+        if (!schemaUrl || !schemaUrl.endsWith(".json")) {
+            alert("Schema URL not provided or is not valid.\n" +
+                "URL must end with '.json'")
+            return false
+        }
+
+        let surveyType = document.querySelector("#schema-url-survey-type").value
+        if (surveyType === "Select Survey Type") {
+            alert("Select a Survey Type.")
+            return false
+        }
+
+        clearAndDisableSchemaNameSelection()
+
+        let schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+
+        loadSurveyMetadata(schemaName, surveyType)
+        loadSchemaMetadata(schemaName, schemaUrl)
+
+        if (surveyType === "test") {
+            let schemaUrlNameInput = document.querySelector("#schema-url-name-input")
+            schemaUrlNameInput.value = schemaName
+            schemaUrlNameInput.disabled = false
+            document.querySelector("#schema-url-name").style.display = "inline"
+        }
+
+        return false
+    }
+
+    function loadSurveyMetadata(schema_name, survey_type) {
         document.querySelector("#submit-btn").disabled = true;
         document.querySelector("#flush-btn").disabled = true;
-
-        const schema_name = document.querySelector("#schema_name").value
-        const survey_type = document.querySelector(`#schema_name option[value="${schema_name}"]`).dataset.surveyType
 
         if (survey_type.toLowerCase() === "test") {
             clearSurveyMetadataFields()
         } else {
             includeSurveyMetadataFields(schema_name, survey_type)
         }
+    }
 
+    function loadSchemaMetadata(schemaName, schemaUrl) {
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
             if (this.readyState == 4) {
@@ -212,10 +307,17 @@
 
                 } else {
                     document.querySelector("#survey_metadata").innerHTML = "Failed to load Schema Metadata";
+                    alert("Failed to load Schema Metadata")
                 }
             }
         };
-        xhttp.open("GET", "/metadata?schema=" + document.querySelector("#schema_name").value, true);
+
+        let queryParam = `schema_name=${schemaName}`
+        if (schemaUrl)  {
+            queryParam += `&schema_url=${schemaUrl}`
+        }
+
+        xhttp.open("GET", `/metadata?${queryParam}`, true);
         xhttp.send();
     }
 
@@ -252,8 +354,8 @@
     }
 
     function validateResponseExpiresAt() {
-        response_expires_at = Date.parse(document.querySelector('#response_expires_at').value)
-        if (isNaN(response_expires_at)) {
+        let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
+        if (isNaN(responseExpiresAt)) {
             document.querySelector('#response_expires_at').remove()
         }
     }


### PR DESCRIPTION
### What is the context of this PR?
- Added the ability to specify a schema URL instead of selecting a schema from runner.
- Specifying a URL means that the runner claims will include a `survey_url` field which runner will use to launch.

> Note: Runner current implementation requires `schema_name` or `eq_id` and `form_type`. Therefore, when launching using a URL, schema name is passed for test schemas and for non test schema eq_id and form_type are passed. This is likely to change in future iterations.

### How to review 

Run this branch via docker or locally.
***Note: You need to clear your browsers cache since the CSS has changed.***

Ensure:
- you are able to specify a schema URL and launch the questionnaire. Validate runner did in fact launch using `survey_url` and was not loaded from file system. Use a schema that doesn't exist in runner.
- the existing behaviour of selecting from the schema list is unaffected.
- when launching using a schema URL, runner's downstream payload contains `collection.schema_name`.