### PR TITLE
Add support for PHM metadata

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -137,7 +137,15 @@ func isSurveyMetadata(key string) bool {
 		"ru_ref",
 		"trad_as",
 		"user_id",
-		"qid":
+		"qid",
+		"PARTICIPANT_ID",
+		"COLLEX_OPEN_DATE",
+	    "COLLEX_END_DATE",
+	    "FIRST_NAME",
+	    "BLOOD_TEST_BARCODE",
+	    "SWAB_TEST_BARCODE",
+	    "TEST_QUESTIONS":
+
 		return true
 	}
 	return false
@@ -627,7 +635,12 @@ func GetRequiredMetadata(launcherSchema surveys.LauncherSchema) ([]Metadata, str
 	defaults := GetDefaultValues()
 
 	for i, value := range schema.Metadata {
-		schema.Metadata[i].Default = defaults[value.Name]
+
+	    if strings.Contains(value.Name, "BARCODE") {
+	       schema.Metadata[i].Default = "BAR" + fmt.Sprintf("%08d", rand.Int63n(1e8))
+	    } else {
+	        schema.Metadata[i].Default = defaults[value.Name]
+	    }
 
 		if value.Validator == "boolean" {
 			schema.Metadata[i].Default = "false"
@@ -759,6 +772,12 @@ func GetDefaultValues() map[string]string {
 	defaults["postcode"] = "PE12 4GH"
 	defaults["display_address"] = "68 Abingdon Road, Goathill"
 	defaults["country"] = "E"
+	defaults["PARTICIPANT_ID"] = "ABC-" + fmt.Sprintf("%011d", rand.Int63n(1e11))
+	defaults["COLLEX_OPEN_DATE"] = "17 Oct 2022"
+	defaults["COLLEX_END_DATE"] = "17 Oct 2022"
+	defaults["FIRST_NAME"] = "John"
+	defaults["TEST_QUESTIONS"] = "F"
+
 
 	return defaults
 }

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -124,27 +124,25 @@ type Metadata struct {
 func isSurveyMetadata(key string) bool {
 	switch key {
 	case
-		"case_ref",
-		"case_type",
-		"display_address",
-		"employment_date",
-		"form_type",
-		"period_id",
-		"period_str",
-		"ref_p_end_date",
-		"ref_p_start_date",
-		"ru_name",
-		"ru_ref",
-		"trad_as",
-		"user_id",
-		"qid",
-		"PARTICIPANT_ID",
-		"COLLEX_OPEN_DATE",
-	    "COLLEX_END_DATE",
-	    "FIRST_NAME",
-	    "BLOOD_TEST_BARCODE",
-	    "SWAB_TEST_BARCODE",
-	    "TEST_QUESTIONS":
+        "case_ref",
+        "case_type",
+        "display_address",
+        "employment_date",
+        "form_type",
+        "period_id",
+        "period_str",
+        "ref_p_end_date",
+        "ref_p_start_date",
+        "ru_name",
+        "ru_ref",
+        "trad_as",
+        "user_id",
+        "qid",
+        "PARTICIPANT_ID",
+        "FIRST_NAME",
+        "BLOOD_TEST_BARCODE",
+        "SWAB_TEST_BARCODE",
+        "TEST_QUESTIONS":
 
 		return true
 	}
@@ -773,8 +771,6 @@ func GetDefaultValues() map[string]string {
 	defaults["display_address"] = "68 Abingdon Road, Goathill"
 	defaults["country"] = "E"
 	defaults["PARTICIPANT_ID"] = "ABC-" + fmt.Sprintf("%011d", rand.Int63n(1e11))
-	defaults["COLLEX_OPEN_DATE"] = "17 Oct 2022"
-	defaults["COLLEX_END_DATE"] = "17 Oct 2022"
 	defaults["FIRST_NAME"] = "John"
 	defaults["TEST_QUESTIONS"] = "F"
 


### PR DESCRIPTION
### What is the context of this PR?
This adds support for PHM metadata, works for both standard launcher and quick launch. Barcodes are generated based on name and do not have default values. `COLLEX_OPEN_DATE` and `COLLEX_END_DATE` are string types at the moment but can be changed to date types if needed (that will probably require changes in runner).

### How to review 
Add metadata fields to PHM schema, run launcher locally and check if new metadata doesn't break runner, test quick launch.
