### PR TITLE
Ability to launch with the sds_dataset_id

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -720,7 +720,6 @@ func getMandatatoryClaims(surveyType string, defaults map[string]string) []Metad
 			{"ru_ref", "false", defaults["ru_ref"]},
 			{"period_id", "false", defaults["period_id"]},
 			{"user_id", "false", defaults["user_id"]},
-			{"sds_dataset_id", "false", defaults["sds_dataset_id"]},
 		}
 	}
 
@@ -751,6 +750,7 @@ func stringInSlice(a string, list []string) bool {
 func GetDefaultValues() map[string]string {
 	defaults := make(map[string]string)
 	collectionExerciseSid, _ := uuid.NewV4()
+	sdsDatasetId, _ := uuid.NewV4()
 
 	var PARTICIPANT_ID = "ABC-" + fmt.Sprintf("%011d", rand.Int63n(1e11))
 
@@ -782,7 +782,7 @@ func GetDefaultValues() map[string]string {
 	defaults["PARTICIPANT_ID"] = PARTICIPANT_ID
 	defaults["FIRST_NAME"] = "John"
 	defaults["TEST_QUESTIONS"] = "F"
-	defaults["sds_dataset_id"] = "001"
+	defaults["sds_dataset_id"] = sdsDatasetId.String()
 	defaults["survey_id"] = "123"
 	defaults["WINDOW_START_DATE"] = "2023-03-01"
 	defaults["WINDOW_END_DATE"] = "2023-03-31"

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -124,25 +124,26 @@ type Metadata struct {
 func isSurveyMetadata(key string) bool {
 	switch key {
 	case
-        "case_ref",
-        "case_type",
-        "display_address",
-        "employment_date",
-        "form_type",
-        "period_id",
-        "period_str",
-        "ref_p_end_date",
-        "ref_p_start_date",
-        "ru_name",
-        "ru_ref",
-        "trad_as",
-        "user_id",
-        "qid",
-        "PARTICIPANT_ID",
-        "FIRST_NAME",
-        "BLOOD_TEST_BARCODE",
-        "SWAB_TEST_BARCODE",
-        "TEST_QUESTIONS":
+		"case_ref",
+		"case_type",
+		"display_address",
+		"employment_date",
+		"form_type",
+		"period_id",
+		"period_str",
+		"ref_p_end_date",
+		"ref_p_start_date",
+		"ru_name",
+		"ru_ref",
+		"trad_as",
+		"user_id",
+		"qid",
+		"PARTICIPANT_ID",
+		"FIRST_NAME",
+		"BLOOD_TEST_BARCODE",
+		"SWAB_TEST_BARCODE",
+		"TEST_QUESTIONS",
+		"sds_dataset_id":
 
 		return true
 	}
@@ -634,11 +635,11 @@ func GetRequiredMetadata(launcherSchema surveys.LauncherSchema) ([]Metadata, str
 
 	for i, value := range schema.Metadata {
 
-	    if strings.Contains(value.Name, "BARCODE") {
-	       schema.Metadata[i].Default = "BAR" + fmt.Sprintf("%08d", rand.Int63n(1e8))
-	    } else {
-	        schema.Metadata[i].Default = defaults[value.Name]
-	    }
+		if strings.Contains(value.Name, "BARCODE") {
+			schema.Metadata[i].Default = "BAR" + fmt.Sprintf("%08d", rand.Int63n(1e8))
+		} else {
+			schema.Metadata[i].Default = defaults[value.Name]
+		}
 
 		if value.Validator == "boolean" {
 			schema.Metadata[i].Default = "false"
@@ -714,6 +715,7 @@ func getMandatatoryClaims(surveyType string, defaults map[string]string) []Metad
 			{"ru_ref", "false", defaults["ru_ref"]},
 			{"period_id", "false", defaults["period_id"]},
 			{"user_id", "false", defaults["user_id"]},
+			{"sds_dataset_id", "false", defaults["sds_dataset_id"]},
 		}
 	}
 
@@ -773,7 +775,7 @@ func GetDefaultValues() map[string]string {
 	defaults["PARTICIPANT_ID"] = "ABC-" + fmt.Sprintf("%011d", rand.Int63n(1e11))
 	defaults["FIRST_NAME"] = "John"
 	defaults["TEST_QUESTIONS"] = "F"
-
+	defaults["sds_dataset_id"] = "001"
 
 	return defaults
 }

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -143,7 +143,7 @@ func isSurveyMetadata(key string) bool {
 		"BLOOD_TEST_BARCODE",
 		"SWAB_TEST_BARCODE",
 		"TEST_QUESTIONS",
-		"sds_dataset_id":
+		"sds_dataset_id",
 		"WINDOW_START_DATE",
 		"WINDOW_END_DATE",
 		"PORTAL_ID",

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -138,6 +138,7 @@ func isSurveyMetadata(key string) bool {
 		"trad_as",
 		"user_id",
 		"qid",
+		"survey_id",
 		"PARTICIPANT_ID",
 		"FIRST_NAME",
 		"BLOOD_TEST_BARCODE",
@@ -782,6 +783,7 @@ func GetDefaultValues() map[string]string {
 	defaults["FIRST_NAME"] = "John"
 	defaults["TEST_QUESTIONS"] = "F"
 	defaults["sds_dataset_id"] = "001"
+	defaults["survey_id"] = "123"
 	defaults["WINDOW_START_DATE"] = "2023-03-01"
 	defaults["WINDOW_END_DATE"] = "2023-03-31"
 	defaults["PORTAL_ID"] = fmt.Sprintf("%07d", rand.Int63n(1e7))


### PR DESCRIPTION
### What is the context of this PR?

Adds the ability to launch a questionnaire schema with `sds_dataset_id` field set as Survey Metadata. This will allow us to launch surveys with Prepop data.

### How to review

To be tested alongside this PR: https://github.com/ONSdigital/eq-questionnaire-runner/pull/1114

