### PR TITLE
Integrate sds with launcher

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -112,6 +112,7 @@ type QuestionnaireSchema struct {
 	Metadata   []Metadata `json:"metadata"`
 	SchemaName string     `json:"schema_name"`
 	SurveyType string     `json:"theme"`
+	SurveyId   string 	  `json:"survey_id"`
 }
 
 // Metadata is a representation of the metadata within the schema with an additional `Default` value
@@ -630,10 +631,10 @@ func GenerateTokenFromPost(postValues url.Values, launchVersion2 bool) (string, 
 }
 
 // GetRequiredMetadata Gets the required metadata from a schema
-func GetRequiredMetadata(launcherSchema surveys.LauncherSchema) ([]Metadata, string) {
+func GetSurveyData(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, string) {
 	schema, error := getSchema(launcherSchema)
 	if error != "" {
-		return nil, fmt.Sprintf("getSchema failed err: %v", error)
+		return QuestionnaireSchema{}, fmt.Sprintf("getSchema failed err: %v", error)
 	}
 
 	defaults := GetDefaultValues()
@@ -664,7 +665,12 @@ func GetRequiredMetadata(launcherSchema surveys.LauncherSchema) ([]Metadata, str
 		schema.Metadata = append(schema.Metadata, v)
 	}
 
-	return schema.Metadata, ""
+	return schema, ""
+}
+
+func GetRequiredMetadata(launcherSchema surveys.LauncherSchema) ([]Metadata, string) {
+	surveyData, err := GetSurveyData(launcherSchema)
+	return surveyData.Metadata, err
 }
 
 func getSchema(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, string) {

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -112,7 +112,7 @@ type QuestionnaireSchema struct {
 	Metadata   []Metadata `json:"metadata"`
 	SchemaName string     `json:"schema_name"`
 	SurveyType string     `json:"theme"`
-	SurveyId   string 	  `json:"survey_id"`
+	SurveyId   string     `json:"survey_id"`
 }
 
 // Metadata is a representation of the metadata within the schema with an additional `Default` value
@@ -630,7 +630,6 @@ func GenerateTokenFromPost(postValues url.Values, launchVersion2 bool) (string, 
 	return token, ""
 }
 
-// GetRequiredMetadata Gets the required metadata from a schema
 func GetSurveyData(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, string) {
 	schema, error := getSchema(launcherSchema)
 	if error != "" {
@@ -668,6 +667,7 @@ func GetSurveyData(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, 
 	return schema, ""
 }
 
+// GetRequiredMetadata Gets the required metadata from a schema
 func GetRequiredMetadata(launcherSchema surveys.LauncherSchema) ([]Metadata, string) {
 	surveyData, err := GetSurveyData(launcherSchema)
 	return surveyData.Metadata, err

--- a/launch.go
+++ b/launch.go
@@ -84,22 +84,22 @@ func postLaunchHandler(w http.ResponseWriter, r *http.Request) {
 	redirectURL(w, r)
 }
 
-func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
+func getSurveyDataHandler(w http.ResponseWriter, r *http.Request) {
 	schemaName := r.URL.Query().Get("schema_name")
 	schemaUrl := r.URL.Query().Get("schema_url")
 
 	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl)
 
-	metadata, err := authentication.GetRequiredMetadata(launcherSchema)
+	surveyData, err := authentication.GetSurveyData(launcherSchema)
 
 	if err != "" {
 		http.Error(w, fmt.Sprintf("GetRequiredMetadata err: %v", err), 500)
 		return
 	}
 
-	metadataJSON, _ := json.Marshal(metadata)
+	surveyDataJSON, _ := json.Marshal(surveyData)
 
-	w.Write([]byte(metadataJSON))
+	w.Write([]byte(surveyDataJSON))
 
 	return
 }
@@ -220,7 +220,7 @@ func main() {
 	// Launch handlers
 	r.HandleFunc("/", getLaunchHandler).Methods("GET")
 	r.HandleFunc("/", postLaunchHandler).Methods("POST")
-	r.HandleFunc("/metadata", getMetadataHandler).Methods("GET")
+	r.HandleFunc("/survey-data", getSurveyDataHandler).Methods("GET")
 	r.HandleFunc("/supplementary-data", getSupplementaryDataHandler).Methods("GET")
 
 	//Author Launcher with passed parameters in Url

--- a/launch.go
+++ b/launch.go
@@ -93,7 +93,7 @@ func getSurveyDataHandler(w http.ResponseWriter, r *http.Request) {
 	surveyData, err := authentication.GetSurveyData(launcherSchema)
 
 	if err != "" {
-		http.Error(w, fmt.Sprintf("GetRequiredMetadata err: %v", err), 500)
+		http.Error(w, fmt.Sprintf("GetSurveyData err: %v", err), 500)
 		return
 	}
 

--- a/launch.go
+++ b/launch.go
@@ -21,10 +21,6 @@ import (
 	"gopkg.in/square/go-jose.v2/json"
 )
 
-type DatasetMetadata struct {
-	dataset_id string
-}
-
 func randomNumericString(n int) string {
 	var letter = []rune("0123456789")
 

--- a/launch.go
+++ b/launch.go
@@ -2,8 +2,6 @@ package main // import "github.com/ONSdigital/eq-questionnaire-launcher"
 
 import (
 	"fmt"
-	"github.com/ONSdigital/eq-questionnaire-launcher/clients"
-	"io/ioutil"
 	"time"
 
 	"html/template"
@@ -113,31 +111,10 @@ func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
 func getSupplementaryDataHandler(w http.ResponseWriter, r *http.Request) {
 	surveyId := r.URL.Query().Get("survey_id")
 	periodId := r.URL.Query().Get("period_id")
-
-	// datasetList := []DatasetMetadata{}
-
-	apiUrl := settings.Get("SDS_API_URL")
-
-	log.Printf("SDS Api URL: %s", apiUrl)
-
-	url := fmt.Sprintf("%s/v1/dataset_metadata?survey_id=%s&period_id=%s", apiUrl, surveyId, periodId)
-
-	resp, err := clients.GetHTTPClient().Get(url)
-
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Fetching supplementary datasets err: %v", err), 500)
-		return
-	}
-
-	responseBody, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-
-	var datasets DatasetMetadata
-	if err := json.Unmarshal(responseBody, &datasets); err != nil {
-		log.Print(err)
-		//return datasets
-	}
-	//return responseBody
+	datasets := surveys.GetSupplementaryDataSets(surveyId, periodId)
+	log.Print(datasets)
+	datasetJSON, _ := json.Marshal(datasets)
+	w.Write([]byte(datasetJSON))
 }
 
 func getAccountServiceURL(r *http.Request) string {

--- a/launch.go
+++ b/launch.go
@@ -108,7 +108,11 @@ func getSupplementaryDataHandler(w http.ResponseWriter, r *http.Request) {
 	surveyId := r.URL.Query().Get("survey_id")
 	periodId := r.URL.Query().Get("period_id")
 
-	datasets := surveys.GetSupplementaryDataSets(surveyId, periodId)
+	datasets, err := surveys.GetSupplementaryDataSets(surveyId, periodId)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("GetSupplementaryDataSets err: %v", err), 500)
+		return
+	}
 	datasetJSON, _ := json.Marshal(datasets)
 
 	w.Write([]byte(datasetJSON))

--- a/launch.go
+++ b/launch.go
@@ -107,9 +107,10 @@ func getMetadataHandler(w http.ResponseWriter, r *http.Request) {
 func getSupplementaryDataHandler(w http.ResponseWriter, r *http.Request) {
 	surveyId := r.URL.Query().Get("survey_id")
 	periodId := r.URL.Query().Get("period_id")
+
 	datasets := surveys.GetSupplementaryDataSets(surveyId, periodId)
-	log.Print(datasets)
 	datasetJSON, _ := json.Marshal(datasets)
+
 	w.Write([]byte(datasetJSON))
 }
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -20,6 +20,7 @@ func init() {
 	setSetting("SURVEY_RUNNER_SCHEMA_URL", Get("SURVEY_RUNNER_URL"))
 	setSetting("SCHEMA_VALIDATOR_URL", "")
 	setSetting("SURVEY_REGISTER_URL", "")
+	setSetting("SDS_API_URL", "http://localhost:5003")
 	setSetting("JWT_ENCRYPTION_KEY_PATH", "jwt-test-keys/sdc-user-authentication-encryption-sr-public-key.pem")
 	setSetting("JWT_SIGNING_KEY_PATH", "jwt-test-keys/sdc-user-authentication-signing-launcher-private-key.pem")
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,7 +11,7 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
     position: relative;
 }
 
-.field-container--hidden, .metadata-fields--hidden, .button--hidden, .group-title--hidden, .supplementary-data-fields--hidden {
+.field-container--hidden, .metadata-fields--hidden, .button--hidden, .group-title--hidden, .supplementary-data--hidden {
     display:none;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,7 +11,7 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
     position: relative;
 }
 
-.field-container--hidden, .metadata-fields--hidden, .button--hidden, .group-title--hidden {
+.field-container--hidden, .metadata-fields--hidden, .button--hidden, .group-title--hidden, .supplementary-data-fields--hidden {
     display:none;
 }
 

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -208,7 +208,6 @@ func GetSupplementaryDataSets(surveyId string, periodId string) []DatasetMetadat
 		log.Print(err)
 		return datasetList
 	}
-	log.Print(response)
 	return response
 }
 

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -193,8 +193,11 @@ func GetSupplementaryDataSets(surveyId string, periodId string) ([]DatasetMetada
 	url := fmt.Sprintf("%s/v1/dataset_metadata?survey_id=%s&period_id=%s", hostURL, surveyId, periodId)
 	resp, err := clients.GetHTTPClient().Get(url)
 
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil || (resp.StatusCode != 200 && resp.StatusCode != 404){
 		return datasetList, errors.New("unable to fetch supplementary data")
+	}
+	if resp.StatusCode == 404 {
+		return datasetList, nil
 	}
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -278,23 +278,6 @@
         }
     }
 
-    async function loadSurveySupplementaryDatasets(schema_name, survey_id, period_id) {
-        var xhttp = new XMLHttpRequest();
-        xhttp.onreadystatechange = function () {
-            if (this.readyState == 4) {
-                if (this.status == 200) {
-                    var response = JSON.parse(this.responseText);
-                    console.log(response);
-                    return response
-                }
-                return []
-            }
-        }
-        let queryParam = `survey_id=${survey_id}&period_id=${period_id}`
-        xhttp.open("GET", `/v1/dataset_metadata?${queryParam}`, true);
-        xhttp.send();
-    }
-
     async function getDataAsync(queryParam) {
         return new Promise((resolve, reject) => {
             console.log(`GETing ${queryParam}`)
@@ -335,8 +318,8 @@
         getDataAsync(survey_data_url)
             .then(schema_response => {
                 console.log(schema_response)
-                const survey_id = (attr = schema_response.find(f => f["name"] == "survey_id")) && attr["default"]
-                const period_id = (attr = schema_response.find(f => f["name"] == "period_id")) && attr["default"]
+                const survey_id = schema_response.find(f => f["name"] === "survey_id")?.["default"]
+                const period_id = schema_response.find(f => f["name"] === "period_id")?.["default"]
                 console.log(JSON.stringify(survey_id))
                 console.log(JSON.stringify(period_id))
                 if (survey_id && period_id) {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -70,9 +70,8 @@
                 <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
             </div>
 
-            <h3 class="group-title--hidden">Supplementary Data</h3>
-            <div id="supplementary_data" class="supplementary-data-fields--hidden">
-                <p>--- Supplementary data fields will be loaded when you select a version, schema and supplementary dataset ---</p>
+            <h3 class="supplementary-data--hidden">Supplementary Data</h3>
+            <div class="supplementary-data--hidden" id="supplementary_data">
             </div>
 
             <h3 class="group-title--hidden">Required Data</h3>
@@ -162,15 +161,19 @@
 
     function clearSurveyMetadataFields() {
         document.querySelector('#survey_metadata_fields').innerHTML = ""
-        document.querySelector('#supplementary_data').innerHTML = ""
+        hideSupplementaryData()
+    }
+
+    function showSupplementaryData () {
+        document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'block');
+    }
+
+    function hideSupplementaryData () {
+        document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'none');
     }
 
     function showAllDivs() {
         document.querySelectorAll("#survey_metadata, .field-container--hidden, .group-title--hidden").forEach(function (element) {
-            element.style.display = 'block';
-        });
-        // TODO only render if selected survey uses supplementary data?
-        document.querySelectorAll("#supplementary_data, .field-container--hidden, .group-title--hidden").forEach(function (element) {
             element.style.display = 'block';
         });
 
@@ -323,6 +326,7 @@
         if (schemaUrl ){
             survey_data_url += `&schema_url=${schemaUrl}`
         }
+        hideSupplementaryData()
         getDataAsync(survey_data_url)
             .then(schema_response => {
                 const survey_id = schema_response.find(f => f["name"] === "survey_id")?.["default"]
@@ -383,6 +387,7 @@
 
                 if (sds_metadata_response) {
                     supplementaryDataSets = sds_metadata_response
+                    showSupplementaryData()
                     loadSupplementaryDataInfo()
                 }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -70,6 +70,11 @@
                 <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
             </div>
 
+            <h3 class="group-title--hidden">Supplementary Data</h3>
+            <div id="supplementary_data" class="supplementary-data-fields--hidden">
+                <p>--- Supplementary data fields will be loaded when you select a version, schema and supplementary dataset ---</p>
+            </div>
+
             <h3 class="group-title--hidden">Required Data</h3>
 
             <div class="field-container field-container--hidden">
@@ -152,12 +157,21 @@
     // uuidv4: from https://github.com/kelektiv/node-uuid
     !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
+    //debugger
+    // store fetch so it only needs to be re-done if the survey changes
+    let supplementaryDataSets = null;
+
     function clearSurveyMetadataFields() {
         document.querySelector('#survey_metadata_fields').innerHTML = ""
+        document.querySelector('#supplementary_data').innerHTML = ""
     }
 
     function showAllDivs() {
         document.querySelectorAll("#survey_metadata, .field-container--hidden, .group-title--hidden").forEach(function (element) {
+            element.style.display = 'block';
+        });
+        // TODO only render if selected survey uses supplementary data?
+        document.querySelectorAll("#supplementary_data, .field-container--hidden, .group-title--hidden").forEach(function (element) {
             element.style.display = 'block';
         });
 
@@ -176,6 +190,7 @@
         let formTypeValue = schema_name.split("_").slice(1).join("_")
 
         document.querySelector('#survey_metadata_fields').style.display = "block";
+        document.querySelector('#supplementary_data').style.display = "block";
 
         if (launchPattern === "v1") {
             document.querySelector('#survey_metadata_fields').innerHTML = `
@@ -280,16 +295,12 @@
 
     async function getDataAsync(queryParam) {
         return new Promise((resolve, reject) => {
-            console.log(`GETing ${queryParam}`)
-            var xhttp = new XMLHttpRequest();
+            let xhttp = new XMLHttpRequest();
             xhttp.onreadystatechange = function() {
-                if (this.readyState == 4) {
-                    console.log(`Ready state 4`)
-                    if (this.status == 200) {
-                        console.log(`Status 200`)
+                if (this.readyState === 4) {
+                    if (this.status === 200) {
                         resolve(JSON.parse(this.responseText))
                     } else {
-                        console.log(this.responseText)
                         reject(`Request failed. ${this.responseText}`)
                     }
                 }
@@ -302,12 +313,10 @@
     function getLabelFor(fieldName){
         return `<label for="${fieldName}">${fieldName}</label>`
     }
-    function getInputField(fieldName, type, defaultValue=null){
+    function getInputField(fieldName, type, defaultValue=null, isReadOnly=false){
         const value = defaultValue ? `value=${defaultValue}` : ''
-        return `<input id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}">`
-    }
-    function getDropDownField(fieldName, options) {
-        return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}">${options.join("")}</select>`
+        const readOnly = isReadOnly ? 'readonly' : ''
+        return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}">`
     }
 
     function loadSchemaMetadata(schemaName, schemaUrl) {
@@ -317,11 +326,9 @@
         }
         getDataAsync(survey_data_url)
             .then(schema_response => {
-                console.log(schema_response)
                 const survey_id = schema_response.find(f => f["name"] === "survey_id")?.["default"]
                 const period_id = schema_response.find(f => f["name"] === "period_id")?.["default"]
-                console.log(JSON.stringify(survey_id))
-                console.log(JSON.stringify(period_id))
+
                 if (survey_id && period_id) {
                     const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
                     return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
@@ -331,24 +338,22 @@
                 }
             })
             .then(([schema_response, sds_metadata_response]) => {
-                console.log(sds_metadata_response)
-                document.querySelector("#survey_metadata").innerHTML = ""
+                document.querySelector("#survey_metadata").innerHTML = "";
+                document.querySelector("#survey_metadata").innerHTML = "";
 
                 if (schema_response.length > 0) {
-                    for (var i = 0; i < schema_response.length; i++) {
-                        metadataField = schema_response[i]
+                    document.querySelector("#survey_metadata").innerHTML = schema_response.map(metadataField => {
 
-                        var defaultValue = metadataField['name'];
+                        const fieldName = metadataField["name"]
+                        let defaultValue = metadataField['default'];
 
                         if (metadataField['type'] === "date") {
-                            var currentDate = new Date()
-                            defaultValue = currentDate.getFullYear() + "-" + ('0' + (currentDate.getMonth() + 1)).slice(-2) + "-" + ('0' + currentDate.getDate()).slice(-2)
+                            const currentDate = new Date()
+                            // format as yyyy-MM-dd
+                            defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
                         }
 
-                        defaultValue = metadataField['default']
-                        const fieldName = metadataField["name"]
-
-                        const metadataFieldHtml = `<div class="field-container">${getLabelFor(fieldName)}${
+                        return `<div class="field-container">${getLabelFor(fieldName)}${
                             (() => {
                                 if (metadataField['type'] === "boolean") {
                                     return getInputField(fieldName, "checkbox");
@@ -361,20 +366,25 @@
                                     );
                                 }
                                 else if (fieldName === "sds_dataset_id") {
-                                    return getDropDownField(fieldName, sds_metadata_response.map(dataset =>
-                                        `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`
-                                    ));
+                                    return (
+                                        `<select onchange="loadSupplementaryDataInfo()" id="${fieldName}" name="${fieldName}" class="qa-${fieldName}">` +
+                                        sds_metadata_response.map(dataset => `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`) +
+                                        `</select>`
+                                    )
                                 }
                                 else {
                                     return getInputField(fieldName, "text", defaultValue)
                                 }
                             })()
                         }</div>`
-
-                        document.querySelector("#survey_metadata").innerHTML = document.querySelector("#survey_metadata").innerHTML + metadataFieldHtml;
-                    }
+                    }).join("")
                 } else {
                     document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                }
+
+                if (sds_metadata_response) {
+                    supplementaryDataSets = sds_metadata_response
+                    loadSupplementaryDataInfo()
                 }
 
                 document.querySelector("#flush-btn").style.display = 'inline-block';
@@ -385,21 +395,33 @@
             })
     }
 
+    function loadSupplementaryDataInfo () {
+        const selectedDatasetId = document.getElementById("sds_dataset_id").value;
+        const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
+
+        selectedDataset && (
+            // TODO might want to only show some of these
+            document.querySelector("#supplementary_data").innerHTML = Object.keys(selectedDataset).map(
+                key => `<div class="field-container">${getLabelFor(key)}${getInputField(selectedDataset[key], "text", selectedDataset[key], true)}</div>`
+            ).join('')
+        )
+    }
+
     function uuid(el_id) {
         document.querySelector(`#${el_id}`).value = uuidv4();
     }
 
     function numericId() {
-        var result = '';
-        var chars = '0123456789';
-        for (var i = 16; i > 0; --i) {
+        let result = '';
+        let chars = '0123456789';
+        for (let i = 16; i > 0; --i) {
             result += chars[Math.round(Math.random() * (chars.length - 1))];
         }
         document.querySelector(`#response_id`).value = result;
     }
 
     function setResponseExpiry(days_offset=7) {
-        var dt = new Date();
+        let dt = new Date();
         dt.setDate(dt.getDate()+days_offset)
         document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
     }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -329,14 +329,14 @@
                 console.log(JSON.stringify(survey_id))
                 console.log(JSON.stringify(period_id))
                 if (survey_id && period_id) {
-                    const sds_dataset_metadata_url = `http://localhost:5003/v1/dataset_metadata?survey_id=${survey_id}&period_id=${period_id}`
+                    const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
                     return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
                 } else {
                     // error
                 }
             })
             .then(([schema_response, sds_metadata_response]) => {
-                console.log(`Got ${sds_metadata_response}`)
+                console.log(sds_metadata_response)
                 document.querySelector("#survey_metadata").innerHTML = ""
 
                 if (schema_response.length > 0) {
@@ -375,7 +375,7 @@
                             metadataFieldHtml = `<div class="field-container">` +
                                 `<label for="${metadataField['name']}">${metadataField['name']}</label>` +
                                 `<select id="${metadataField['name']}" name="${metadataField['name']}" class="qa-${metadataField['name']}">` +
-                                sds_metadata_response.map(dataset_id => `<option value="${dataset_id}">${dataset_id}</option>`).join("") +
+                                sds_metadata_response.map(dataset => `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`).join("") +
                                 "</select></div>"
                             console.log(metadataFieldHtml)
                         } else {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -303,6 +303,7 @@
                     if (this.status === 200) {
                         resolve(JSON.parse(this.responseText))
                     } else {
+                        alert(`Request failed. ${this.responseText}`)
                         reject(`Request failed. ${this.responseText}`)
                     }
                 }
@@ -330,6 +331,15 @@
         return null
     }
 
+    function handleNoSupplementaryData() {
+
+        hideSupplementaryData()
+        document.querySelector("#sds_dataset_id").innerHTML = null
+        document.querySelector(`#submit-btn`).style.display = 'none';
+        document.querySelector("#flush-btn").style.display = 'none';
+
+    }
+
     function updateSDSDropdown() {
         const surveyId = document.getElementById("survey_id")?.value;
         const periodId = document.getElementById("period_id")?.value;
@@ -344,12 +354,10 @@
                     loadSupplementaryDataInfo()
                     displayLaunchButton(false)
                 } else {
-                    hideSupplementaryData()
-                    document.querySelector("#sds_dataset_id").innerHTML = null
-                    document.querySelector(`#submit-btn`).style.display = 'none';
-                    document.querySelector("#flush-btn").style.display = 'none';
+                    handleNoSupplementaryData()
                 }
             })
+            .catch(_ => handleNoSupplementaryData())
     }
 
     function loadSchemaMetadata(schemaName, schemaUrl) {
@@ -406,9 +414,8 @@
 
                 document.querySelector("#flush-btn").style.display = 'inline-block';
             })
-            .catch(err => {
-                document.querySelector("#survey_metadata").innerHTML = "Failed to load Schema or SDS Dataset Metadata";
-                alert(`Failed to load Schema Metadata or SDS Dataset\n${err}`)
+            .catch(_ => {
+                document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
             })
     }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -278,14 +278,16 @@
         }
     }
 
-    function loadSurveySupplementaryDatasets(schema_name, survey_id, period_id) {
+    async function loadSurveySupplementaryDatasets(schema_name, survey_id, period_id) {
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function () {
             if (this.readyState == 4) {
                 if (this.status == 200) {
                     var response = JSON.parse(this.responseText);
                     console.log(response);
+                    return response
                 }
+                return []
             }
         }
         let queryParam = `survey_id=${survey_id}&period_id=${period_id}`
@@ -293,84 +295,108 @@
         xhttp.send();
     }
 
-    function loadSchemaMetadata(schemaName, schemaUrl) {
-        var xhttp = new XMLHttpRequest();
-        xhttp.onreadystatechange = function() {
-            if (this.readyState == 4) {
-                if (this.status == 200) {
-
-                    document.querySelector("#survey_metadata").innerHTML = ""
-
-                    var response = JSON.parse(this.responseText);
-
-                    if (response.length > 0) {
-                        for (var i = 0; i < response.length; i++) {
-                            metadataField = response[i]
-
-                            var defaultValue = metadataField['name'];
-
-                            if (metadataField['type'] == "date") {
-                                var currentDate = new Date()
-                                var defaultValue = currentDate.getFullYear() + "-" + ('0' + (currentDate.getMonth() + 1)).slice(-2) + "-" + ('0' + currentDate.getDate()).slice(-2)
-                            }
-
-                            defaultValue = metadataField['default']
-
-                            var metadataFieldHtml = "";
-
-                            if (metadataField['type'] == "boolean") {
-
-                                metadataFieldHtml = "<div class=\"field-container\">" +
-                                    "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
-                                    "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"checkbox\" name=\"" + metadataField['name'] + "\" class=\"qa-" + metadataField['name'] + "\">" +
-                                    "</div>"
-
-                            } else if (metadataField['type'] == "uuid") {
-
-                                metadataFieldHtml = "<div class=\"field-container\">" +
-                                    "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
-                                    "<span  class=\"field-container__span\">" +
-                                    "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"text\" value=\"" + uuidv4() + "\" class=\"" + metadataField['name'] + "\">" +
-                                    "<img class=\"field-container__img\" onclick=\"uuid('" + metadataField['name'] + "')\" src=\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==\">" +
-                                    "</span>" +
-                                    "</div>"
-
-                            } else if (metadataField['name'] == "sds_dataset_id"){
-                                metadataFieldHtml = `<div class="field-container">` +
-                                    `<label for="${metadataField['name']}">${metadataField['name']}</label>` +
-                                    `<select id="${metadataField['name']}" name="${metadataField['name']}" class="qa-${metadataField['name']}">` +
-                                    [1, 2, 3].map(dataset_id => `<option value="${dataset_id}">${dataset_id}</option>`).join("") +
-                                    "</select></div>"
-                                console.log(metadataFieldHtml)
-                            } else {
-                                metadataFieldHtml = "<div class=\"field-container\">" +
-                                    "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
-                                    "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"text\" value=\"" + defaultValue + "\" class=\"qa-" + metadataField['name'] + "\">" +
-                                    "</div>"
-                            }
-
-                            document.querySelector("#survey_metadata").innerHTML = document.querySelector("#survey_metadata").innerHTML + metadataFieldHtml;
-                        }
+    async function getDataAsync(queryParam) {
+        return new Promise((resolve, reject) => {
+            console.log(`GETing ${queryParam}`)
+            var xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function() {
+                if (this.readyState == 4) {
+                    console.log(`Ready state 4`)
+                    if (this.status == 200) {
+                        console.log(`Status 200`)
+                        resolve(JSON.parse(this.responseText))
                     } else {
-                        document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                        console.log(this.responseText)
+                        reject(`Request failed. ${this.responseText}`)
                     }
-
-                    document.querySelector("#flush-btn").style.display = 'inline-block';
-
-                } else {
-                    document.querySelector("#survey_metadata").innerHTML = "Failed to load Schema Metadata";
-                    alert("Failed to load Schema Metadata")
                 }
-            }
-        };
+            };
+            xhttp.open("GET", queryParam, true);
+            xhttp.send();
+        })
+    }
 
-        let queryParam = `schema_name=${schemaName}`
-        if (schemaUrl)  {
-            queryParam += `&schema_url=${schemaUrl}`
+    function loadSchemaMetadata(schemaName, schemaUrl) {
+        let survey_data_url = `/metadata?schema_name=${schemaName}`
+        if (schemaUrl ){
+            survey_data_url += `&schema_url=${schemaUrl}`
         }
+        getDataAsync(survey_data_url)
+            .then(schema_response => {
+                console.log(`Got ${schema_response}`)
+                const survey_id = schema_response.find(f => f["name"] == "survey_id")["default"]
+                const period_id = schema_response.find(f => f["name"] == "period_id")["default"]
+                console.log(JSON.stringify(survey_id))
+                console.log(JSON.stringify(period_id))
+                if (survey_id && period_id) {
+                    const sds_dataset_metadata_url = `http://localhost:5003/v1/dataset_metadata?survey_id=${survey_id}&period_id=${period_id}`
+                    return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
+                } else {
+                    // error
+                }
+            })
+            .then(([schema_response, sds_metadata_response]) => {
+                console.log(`Got ${sds_metadata_response}`)
+                document.querySelector("#survey_metadata").innerHTML = ""
 
-        xhttp.open("GET", `/metadata?${queryParam}`, true);
-        xhttp.send();
+                if (schema_response.length > 0) {
+                    for (var i = 0; i < schema_response.length; i++) {
+                        metadataField = schema_response[i]
+
+                        var defaultValue = metadataField['name'];
+
+                        if (metadataField['type'] == "date") {
+                            var currentDate = new Date()
+                            var defaultValue = currentDate.getFullYear() + "-" + ('0' + (currentDate.getMonth() + 1)).slice(-2) + "-" + ('0' + currentDate.getDate()).slice(-2)
+                        }
+
+                        defaultValue = metadataField['default']
+
+                        var metadataFieldHtml = "";
+
+                        if (metadataField['type'] == "boolean") {
+
+                            metadataFieldHtml = "<div class=\"field-container\">" +
+                                "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
+                                "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"checkbox\" name=\"" + metadataField['name'] + "\" class=\"qa-" + metadataField['name'] + "\">" +
+                                "</div>"
+
+                        } else if (metadataField['type'] == "uuid") {
+
+                            metadataFieldHtml = "<div class=\"field-container\">" +
+                                "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
+                                "<span  class=\"field-container__span\">" +
+                                "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"text\" value=\"" + uuidv4() + "\" class=\"" + metadataField['name'] + "\">" +
+                                "<img class=\"field-container__img\" onclick=\"uuid('" + metadataField['name'] + "')\" src=\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==\">" +
+                                "</span>" +
+                                "</div>"
+
+                        } else if (metadataField['name'] == "sds_dataset_id"){
+                            metadataFieldHtml = `<div class="field-container">` +
+                                `<label for="${metadataField['name']}">${metadataField['name']}</label>` +
+                                `<select id="${metadataField['name']}" name="${metadataField['name']}" class="qa-${metadataField['name']}">` +
+                                sds_metadata_response.map(dataset_id => `<option value="${dataset_id}">${dataset_id}</option>`).join("") +
+                                "</select></div>"
+                            console.log(metadataFieldHtml)
+                        } else {
+                            metadataFieldHtml = "<div class=\"field-container\">" +
+                                "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
+                                "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"text\" value=\"" + defaultValue + "\" class=\"qa-" + metadataField['name'] + "\">" +
+                                "</div>"
+                        }
+
+                        document.querySelector("#survey_metadata").innerHTML = document.querySelector("#survey_metadata").innerHTML + metadataFieldHtml;
+                    }
+                } else {
+                    document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                }
+
+                document.querySelector("#flush-btn").style.display = 'inline-block';
+            })
+            .catch(err => {
+                document.querySelector("#survey_metadata").innerHTML = "Failed to load Schema Metadata";
+                alert("Failed to load Schema Metadata")
+            })
     }
 
     function uuid(el_id) {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -333,7 +333,6 @@
     function updateSDSDropdown() {
         const surveyId = document.getElementById("survey_id")?.value;
         const periodId = document.getElementById("period_id")?.value;
-        hideSupplementaryData()
         loadSDSDatasetMetadata(surveyId, periodId)
             .then(sds_metadata_response => {
                 if (sds_metadata_response?.length) {
@@ -343,6 +342,12 @@
                         `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
                         .join("");
                     loadSupplementaryDataInfo()
+                    displayLaunchButton(false)
+                } else {
+                    hideSupplementaryData()
+                    document.querySelector("#sds_dataset_id").innerHTML = null
+                    document.querySelector(`#submit-btn`).style.display = 'none';
+                    document.querySelector("#flush-btn").style.display = 'none';
                 }
             })
     }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -329,7 +329,6 @@
         hideSupplementaryData()
         getDataAsync(survey_data_url)
             .then(schema_response => {
-                console.log(schema_response)
                 const survey_id = schema_response.survey_id
                 const period_id = schema_response.metadata.find(f => f["name"] === "period_id")?.["default"]
 
@@ -342,9 +341,6 @@
                 }
             })
             .then(([schema_response, sds_metadata_response]) => {
-                debugger
-                console.log(schema_response)
-                console.log(sds_metadata_response)
                 document.querySelector("#survey_metadata").innerHTML = "";
                 document.querySelector("#survey_metadata").innerHTML = "";
 
@@ -406,12 +402,13 @@
     function loadSupplementaryDataInfo () {
         const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
         const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
-        selectedDataset && (
-            // TODO might want to only show some of these
-            document.querySelector("#supplementary_data").innerHTML = Object.keys(selectedDataset).map(
+        if (selectedDataset) {
+            const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
+
+            document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
                 key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
             ).join('')
-        )
+        }
     }
 
     function uuid(el_id) {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -394,8 +394,8 @@
                 document.querySelector("#flush-btn").style.display = 'inline-block';
             })
             .catch(err => {
-                document.querySelector("#survey_metadata").innerHTML = "Failed to load Schema Metadata";
-                alert("Failed to load Schema Metadata")
+                document.querySelector("#survey_metadata").innerHTML = "Failed to load Schema or SDS Dataset Metadata";
+                alert(`Failed to load Schema Metadata or SDS Dataset\n${err}`)
             })
     }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -322,25 +322,29 @@
     }
 
     function loadSchemaMetadata(schemaName, schemaUrl) {
-        let survey_data_url = `/metadata?schema_name=${schemaName}`
+        let survey_data_url = `/survey-data?schema_name=${schemaName}`
         if (schemaUrl ){
             survey_data_url += `&schema_url=${schemaUrl}`
         }
         hideSupplementaryData()
         getDataAsync(survey_data_url)
             .then(schema_response => {
-                const survey_id = schema_response.find(f => f["name"] === "survey_id")?.["default"]
-                const period_id = schema_response.find(f => f["name"] === "period_id")?.["default"]
+                console.log(schema_response)
+                const survey_id = schema_response.survey_id
+                const period_id = schema_response.metadata.find(f => f["name"] === "period_id")?.["default"]
 
                 if (survey_id && period_id) {
                     const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
-                    return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
+                    return Promise.all([schema_response.metadata, getDataAsync(sds_dataset_metadata_url)])
                 } else {
                     // not all metadata has survey_id & period_id
-                    return [schema_response, null]
+                    return [schema_response.metadata, null]
                 }
             })
             .then(([schema_response, sds_metadata_response]) => {
+                debugger
+                console.log(schema_response)
+                console.log(sds_metadata_response)
                 document.querySelector("#survey_metadata").innerHTML = "";
                 document.querySelector("#survey_metadata").innerHTML = "";
 
@@ -400,7 +404,7 @@
     }
 
     function loadSupplementaryDataInfo () {
-        const selectedDatasetId = document.getElementById("sds_dataset_id").value;
+        const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
         const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
         selectedDataset && (
             // TODO might want to only show some of these

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -157,7 +157,6 @@
     // uuidv4: from https://github.com/kelektiv/node-uuid
     !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
-    //debugger
     // store fetch so it only needs to be re-done if the survey changes
     let supplementaryDataSets = null;
 
@@ -314,7 +313,7 @@
         return `<label for="${fieldName}">${fieldName}</label>`
     }
     function getInputField(fieldName, type, defaultValue=null, isReadOnly=false){
-        const value = defaultValue ? `value=${defaultValue}` : ''
+        const value = defaultValue ? `value="${defaultValue}"` : ''
         const readOnly = isReadOnly ? 'readonly' : ''
         return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}">`
     }
@@ -398,11 +397,10 @@
     function loadSupplementaryDataInfo () {
         const selectedDatasetId = document.getElementById("sds_dataset_id").value;
         const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
-
         selectedDataset && (
             // TODO might want to only show some of these
             document.querySelector("#supplementary_data").innerHTML = Object.keys(selectedDataset).map(
-                key => `<div class="field-container">${getLabelFor(key)}${getInputField(selectedDataset[key], "text", selectedDataset[key], true)}</div>`
+                key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
             ).join('')
         )
     }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -355,7 +355,6 @@
                             // format as yyyy-MM-dd
                             defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
                         }
-                        debugger
 
                         return `<div class="field-container">${getLabelFor(fieldName)}${
                             (() => {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -334,18 +334,18 @@
 
                 if (survey_id && period_id) {
                     const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
-                    return Promise.all([schema_response.metadata, getDataAsync(sds_dataset_metadata_url)])
+                    return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
                 } else {
                     // not all metadata has survey_id & period_id
-                    return [schema_response.metadata, null]
+                    return [schema_response, null]
                 }
             })
             .then(([schema_response, sds_metadata_response]) => {
                 document.querySelector("#survey_metadata").innerHTML = "";
                 document.querySelector("#survey_metadata").innerHTML = "";
 
-                if (schema_response.length > 0) {
-                    document.querySelector("#survey_metadata").innerHTML = schema_response.map(metadataField => {
+                if (schema_response.metadata.length > 0) {
+                    document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
 
                         const fieldName = metadataField["name"]
                         let defaultValue = metadataField['default'];
@@ -355,6 +355,7 @@
                             // format as yyyy-MM-dd
                             defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
                         }
+                        debugger
 
                         return `<div class="field-container">${getLabelFor(fieldName)}${
                             (() => {
@@ -367,6 +368,9 @@
                                         `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
                                         `</span>`
                                     );
+                                }
+                                else if (fieldName === "survey_id" && sds_metadata_response) {
+                                    return getInputField(fieldName, "text", schema_response.survey_id);
                                 }
                                 else if (fieldName === "sds_dataset_id") {
                                     return (

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -278,6 +278,21 @@
         }
     }
 
+    function loadSurveySupplementaryDatasets(schema_name, survey_id, period_id) {
+        var xhttp = new XMLHttpRequest();
+        xhttp.onreadystatechange = function () {
+            if (this.readyState == 4) {
+                if (this.status == 200) {
+                    var response = JSON.parse(this.responseText);
+                    console.log(response);
+                }
+            }
+        }
+        let queryParam = `survey_id=${survey_id}&period_id=${period_id}`
+        xhttp.open("GET", `/v1/dataset_metadata?${queryParam}`, true);
+        xhttp.send();
+    }
+
     function loadSchemaMetadata(schemaName, schemaUrl) {
         var xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function() {
@@ -320,6 +335,13 @@
                                     "</span>" +
                                     "</div>"
 
+                            } else if (metadataField['name'] == "sds_dataset_id"){
+                                metadataFieldHtml = `<div class="field-container">` +
+                                    `<label for="${metadataField['name']}">${metadataField['name']}</label>` +
+                                    `<select id="${metadataField['name']}" name="${metadataField['name']}" class="qa-${metadataField['name']}">` +
+                                    [1, 2, 3].map(dataset_id => `<option value="${dataset_id}">${dataset_id}</option>`).join("") +
+                                    "</select></div>"
+                                console.log(metadataFieldHtml)
                             } else {
                                 metadataFieldHtml = "<div class=\"field-container\">" +
                                     "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -316,6 +316,17 @@
         })
     }
 
+    function getLabelFor(fieldName){
+        return `<label for="${fieldName}">${fieldName}</label>`
+    }
+    function getInputField(fieldName, type, defaultValue=null){
+        const value = defaultValue ? `value=${defaultValue}` : ''
+        return `<input id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}">`
+    }
+    function getDropDownField(fieldName, options) {
+        return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}">${options.join("")}</select>`
+    }
+
     function loadSchemaMetadata(schemaName, schemaUrl) {
         let survey_data_url = `/metadata?schema_name=${schemaName}`
         if (schemaUrl ){
@@ -323,16 +334,17 @@
         }
         getDataAsync(survey_data_url)
             .then(schema_response => {
-                console.log(`Got ${schema_response}`)
-                const survey_id = schema_response.find(f => f["name"] == "survey_id")["default"]
-                const period_id = schema_response.find(f => f["name"] == "period_id")["default"]
+                console.log(schema_response)
+                const survey_id = (attr = schema_response.find(f => f["name"] == "survey_id")) && attr["default"]
+                const period_id = (attr = schema_response.find(f => f["name"] == "period_id")) && attr["default"]
                 console.log(JSON.stringify(survey_id))
                 console.log(JSON.stringify(period_id))
                 if (survey_id && period_id) {
                     const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
                     return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
                 } else {
-                    // error
+                    // not all metadata has survey_id & period_id
+                    return [schema_response, null]
                 }
             })
             .then(([schema_response, sds_metadata_response]) => {
@@ -345,45 +357,36 @@
 
                         var defaultValue = metadataField['name'];
 
-                        if (metadataField['type'] == "date") {
+                        if (metadataField['type'] === "date") {
                             var currentDate = new Date()
-                            var defaultValue = currentDate.getFullYear() + "-" + ('0' + (currentDate.getMonth() + 1)).slice(-2) + "-" + ('0' + currentDate.getDate()).slice(-2)
+                            defaultValue = currentDate.getFullYear() + "-" + ('0' + (currentDate.getMonth() + 1)).slice(-2) + "-" + ('0' + currentDate.getDate()).slice(-2)
                         }
 
                         defaultValue = metadataField['default']
+                        const fieldName = metadataField["name"]
 
-                        var metadataFieldHtml = "";
-
-                        if (metadataField['type'] == "boolean") {
-
-                            metadataFieldHtml = "<div class=\"field-container\">" +
-                                "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
-                                "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"checkbox\" name=\"" + metadataField['name'] + "\" class=\"qa-" + metadataField['name'] + "\">" +
-                                "</div>"
-
-                        } else if (metadataField['type'] == "uuid") {
-
-                            metadataFieldHtml = "<div class=\"field-container\">" +
-                                "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
-                                "<span  class=\"field-container__span\">" +
-                                "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"text\" value=\"" + uuidv4() + "\" class=\"" + metadataField['name'] + "\">" +
-                                "<img class=\"field-container__img\" onclick=\"uuid('" + metadataField['name'] + "')\" src=\"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==\">" +
-                                "</span>" +
-                                "</div>"
-
-                        } else if (metadataField['name'] == "sds_dataset_id"){
-                            metadataFieldHtml = `<div class="field-container">` +
-                                `<label for="${metadataField['name']}">${metadataField['name']}</label>` +
-                                `<select id="${metadataField['name']}" name="${metadataField['name']}" class="qa-${metadataField['name']}">` +
-                                sds_metadata_response.map(dataset => `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`).join("") +
-                                "</select></div>"
-                            console.log(metadataFieldHtml)
-                        } else {
-                            metadataFieldHtml = "<div class=\"field-container\">" +
-                                "<label for=\"" + metadataField['name'] + "\">" + metadataField['name'] + "</label>" +
-                                "<input id=\"" + metadataField['name'] + "\" name=\"" + metadataField['name'] + "\" type=\"text\" value=\"" + defaultValue + "\" class=\"qa-" + metadataField['name'] + "\">" +
-                                "</div>"
-                        }
+                        const metadataFieldHtml = `<div class="field-container">${getLabelFor(fieldName)}${
+                            (() => {
+                                if (metadataField['type'] === "boolean") {
+                                    return getInputField(fieldName, "checkbox");
+                                }
+                                else if (metadataField['type'] === "uuid") {
+                                    return (
+                                        `<span  class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
+                                        `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
+                                        `</span>`
+                                    );
+                                }
+                                else if (fieldName === "sds_dataset_id") {
+                                    return getDropDownField(fieldName, sds_metadata_response.map(dataset =>
+                                        `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`
+                                    ));
+                                }
+                                else {
+                                    return getInputField(fieldName, "text", defaultValue)
+                                }
+                            })()
+                        }</div>`
 
                         document.querySelector("#survey_metadata").innerHTML = document.querySelector("#survey_metadata").innerHTML + metadataFieldHtml;
                     }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -315,10 +315,36 @@
     function getLabelFor(fieldName){
         return `<label for="${fieldName}">${fieldName}</label>`
     }
-    function getInputField(fieldName, type, defaultValue=null, isReadOnly=false){
+
+    function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
         const value = defaultValue ? `value="${defaultValue}"` : ''
         const readOnly = isReadOnly ? 'readonly' : ''
-        return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}">`
+        return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
+    }
+
+    async function loadSDSDatasetMetadata(survey_id, period_id) {
+        if (survey_id && period_id) {
+            const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
+            return await getDataAsync(sds_dataset_metadata_url)
+        }
+        return null
+    }
+
+    function updateSDSDropdown() {
+        const surveyId = document.getElementById("survey_id")?.value;
+        const periodId = document.getElementById("period_id")?.value;
+        hideSupplementaryData()
+        loadSDSDatasetMetadata(surveyId, periodId)
+            .then(sds_metadata_response => {
+                if (sds_metadata_response?.length) {
+                    supplementaryDataSets = sds_metadata_response
+                    showSupplementaryData()
+                    document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
+                        `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
+                        .join("");
+                    loadSupplementaryDataInfo()
+                }
+            })
     }
 
     function loadSchemaMetadata(schemaName, schemaUrl) {
@@ -329,18 +355,6 @@
         hideSupplementaryData()
         getDataAsync(survey_data_url)
             .then(schema_response => {
-                const survey_id = schema_response.survey_id
-                const period_id = schema_response.metadata.find(f => f["name"] === "period_id")?.["default"]
-
-                if (survey_id && period_id) {
-                    const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
-                    return Promise.all([schema_response, getDataAsync(sds_dataset_metadata_url)])
-                } else {
-                    // not all metadata has survey_id & period_id
-                    return [schema_response, null]
-                }
-            })
-            .then(([schema_response, sds_metadata_response]) => {
                 document.querySelector("#survey_metadata").innerHTML = "";
                 document.querySelector("#survey_metadata").innerHTML = "";
 
@@ -368,15 +382,11 @@
                                         `</span>`
                                     );
                                 }
-                                else if (fieldName === "survey_id" && sds_metadata_response) {
-                                    return getInputField(fieldName, "text", schema_response.survey_id);
+                                else if (fieldName === "survey_id" || fieldName === "period_id") {
+                                    return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
                                 }
                                 else if (fieldName === "sds_dataset_id") {
-                                    return (
-                                        `<select onchange="loadSupplementaryDataInfo()" id="${fieldName}" name="${fieldName}" class="qa-${fieldName}">` +
-                                        sds_metadata_response.map(dataset => `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`) +
-                                        `</select>`
-                                    )
+                                    return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
                                 }
                                 else {
                                     return getInputField(fieldName, "text", defaultValue)
@@ -384,14 +394,9 @@
                             })()
                         }</div>`
                     }).join("")
+                    updateSDSDropdown()
                 } else {
                     document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
-                }
-
-                if (sds_metadata_response) {
-                    supplementaryDataSets = sds_metadata_response
-                    showSupplementaryData()
-                    loadSupplementaryDataInfo()
                 }
 
                 document.querySelector("#flush-btn").style.display = 'inline-block';


### PR DESCRIPTION
### What is the context of this PR?
This PR is the launcher component of the ticket to Integrate SDS with Launcher. When a schema is selected, the `survey_id` of that schema is retrieved and returned along with the metadata so that if the metadata also contains `survey_id`, then it will be pre-populated with the `survey_id` of the survey (to make life easier for devs)

The metadata `survey_id` can be changed to anything, and when both `survey_id` and `period_id` are populated fields in the metadata, and when either of them change, a new call is made to the mock endpoint in the [corresponding runner PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/1147) to fetch the SDS datasets and use them to fill the dropdown list.

### Changes
Adjusted `launch.go` to replace the `metadataHandler` with a `surveyDataHandler`. This is because we need the `survey_id` from the schema, to pre-populate any `survey_id` that might be found in metadata, and it was not enough to return the metadata alone to render the page.

Additionally in `launch.go` added a similar `supplementaryDataHandler` to intercept any requests to the `supplementary-data` url in the front-end and make the request to the mock end point with proper handling

The actual fetching of supplementary datasets is done in `surveys.go` in a similar style to other fetches and using the `DatasetMetadata` struct to model the response, as per the sds api documentation

`launch.html` has been refactored to improve the way fetches were being done, make reusable components for the various input fields and whenever the schema changes and metadata is populated, check for a survey id and period id in the metadata and fetch supplementary datasets if both can be found. 

If supplementary datasets are found, the supplementary data div is displayed and populated with the selected dataset

### How to review

1. Clone and run the [launcher PR](https://github.com/ONSdigital/eq-questionnaire-launcher/pull/49) with `go run launch.go`
2. Run the supporting services for runner with `make dev-compose-up` as normal (delete the launcher container if that is built despite launcher already being run) 
3. Launch the mock SDS from a terminal in runner`python -m scripts.mock_sds_endpoint`
4. Launch runner as normal.
5. Open launcher in chrome
6. Select V2 Launch Pattern and the schema `test_supplementary_data`
7. Survey Metadata should load as normal, with survey id 123 and a new sds_dataset_id dropdown with only one option. 
8. The first and only SDS dataset metadata should have loaded and displayed below.
9. The survey should be launchable.
10. Open launcher again
11. Select V2 Launch Pattern and the schema `test_supplementary_data_with_multiple_datasets`
12. Survey Metadata should load as normal, with survey id 456 and 2 `sds_dataset_ids` in the `sds_dataset_id` dropdown. The first one will auto-select. 
13. Swap between the given options and the Dataset Metadata section should update to reflect the metadata. 
14. Launch the survey with both options to verify it launches correctly. 
15. Open launcher again
16. Select V2 Launch Pattern and either `test_supplementary_data` or `test_supplementary_data_with_multiple_datasets`.
17. Enter a random number for the survey id in the survey metadata section.
18. The Dataset Metadata section should disappear and the `sds_dataset_id` dropdown should clear of options, and the Launch Survey button should not be available, as the survey requires an `sds_dataset_id` value.  
19. In step 17, using the id of the schema you did not load, will load the available datasets for that survey but it will be an invalid dataset for the selected survey and thus crash on launch. 

### How to review

- Read through the trello card and check that the requirements have been met, and that the changes are suitable
- As this is a dev tool, consider if this implementation offers the most helpful functionality it can for working with pre-pop tickets