### PR TITLE
Make v2 default

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,7 +11,7 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
     position: relative;
 }
 
-.field-container--hidden, .button--hidden, .group-title--hidden, .supplementary-data--hidden {
+.btn--hidden, .supplementary-data--hidden {
     display:none;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,7 +11,7 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
     position: relative;
 }
 
-.field-container--hidden, .metadata-fields--hidden, .button--hidden, .group-title--hidden, .supplementary-data--hidden {
+.field-container--hidden, .button--hidden, .group-title--hidden, .supplementary-data--hidden {
     display:none;
 }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -343,11 +343,15 @@
                     if (sds_metadata_response?.length) {
                         supplementaryDataSets = sds_metadata_response
                         toggleSupplementaryData("show");
+                        toggleSubmitFlushButtons("show");
                         document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
                             `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
                             .join("");
-                        loadSupplementaryDataInfo()
-                        displayLaunchButton(false)
+                        loadSupplementaryDataInfo();
+                        displayLaunchButton(false);
+                    } else if (document.querySelector("#sds_dataset_id")) {
+                        document.querySelector("#sds_dataset_id").innerHTML = "";
+                        toggleSubmitFlushButtons("hide");
                     }
                 })
                 .catch(_ => {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -60,11 +60,11 @@
 
                 <p>----------</p>
 
-                <div id="survey_metadata_fields" class="metadata-fields--hidden">
+                <div id="survey_metadata_fields">
                 </div>
 
                 <h3 class="group-title--hidden">Survey Metadata</h3>
-                <div id="survey_metadata" class="metadata-fields--hidden">
+                <div id="survey_metadata">
                     <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
                 </div>
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -1,477 +1,477 @@
-{{define "title"}}Launch a Survey{{end}}
+{{ define "title" }}Launch a Survey{{ end }}
 
-{{define "body"}}
+{{ define "body" }}
 
-<body onbeforeunload='resetDropdowns();'>
-    <h1>Launch a survey</h1>
-    <div>
-        <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
+    <body onbeforeunload='resetDropdowns();'>
+        <h1>Launch a survey</h1>
+        <div>
+            <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
 
-            <strong><u>Launch Pattern</u></strong>
-            <div class="field-container">
-                <label for="launch_pattern">Version</label>
-                <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="showAllDivs(); displayLaunchButton(false);">
-                    <option selected disabled>Select Launch Pattern</option>
-                    <option value="v1">v1</option>
-                    <option value="v2">v2</option>
-                </select>
-            </div>
-
-            <strong><u>Launch by Schema Name</u></strong>
-            <div class="field-container">
-                <label for="schema_name">Schemas</label>
-                <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
-                    <option selected disabled>Select Schema</option>
-
-                    {{ range $surveyType, $schemasList := .Schemas }}
-                        <optgroup label="{{ $surveyType }} Surveys">
-                            {{ range $schema := $schemasList }}
-                                <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
-                            {{ end }}
-                        </optgroup>
-                    {{ end }}
-                </select>
-            </div>
-
-            <p>----------</p>
-
-            <strong><u>Launch by Schema URL</u></strong>
-
-            <div class="field-container">
-                <span class="field-container__span">
-                    <label for="schema-url-survey-type">Survey Type</label>
-                    <select name="survey-types" id="schema-url-survey-type">
-                        <option selected disabled>Select Survey Type</option>
-                        {{ range $surveyType, $schemasList := .Schemas }}
-                        <option value="{{ $surveyType }}">{{ $surveyType }}</option>
-                    {{ end }}
+                <strong><u>Launch Pattern</u></strong>
+                <div class="field-container">
+                    <label for="launch_pattern">Version</label>
+                    <select id="launch_pattern" name="launch_version" class="qa-select-launch-version">
+                        <option value="v1">v1</option>
+                        <option value="v2" selected="selected">v2</option>
                     </select>
-                </span>
-            </div>
-
-            <div class="field-container">
-                <span class="field-container__span">
-                    <label for="schema-url">Schema URL</label>
-                    <input id="schema-url" name="schema_url" type="text" class="qa-schema_url">
-                </span>
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <input type="submit" onClick="displayLaunchButton(true); return loadMetadataForSchemaUrl();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
-            </div>
-
-            <p>----------</p>
-
-            <div id="survey_metadata_fields" class="metadata-fields--hidden">
-            </div>
-
-            <h3 class="group-title--hidden">Survey Metadata</h3>
-            <div id="survey_metadata" class="metadata-fields--hidden">
-                <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
-            </div>
-
-            <h3 class="supplementary-data--hidden">Supplementary Data</h3>
-            <div class="supplementary-data--hidden" id="supplementary_data">
-            </div>
-
-            <h3 class="group-title--hidden">Required Data</h3>
-
-            <div class="field-container field-container--hidden">
-                <label for="case_id">Case ID</label>
-                <span class="field-container__span">
-                    <input id="case_id" name="case_id" type="text" class="qa-case_id">
-                    <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="response_id">Response ID</label>
-                <span class="field-container__span">
-                    <input id="response_id" name="response_id" type="text" class="qa-response_id">
-                    <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="collection_exercise_sid">Collection Exercise SID</label>
-                <span class="field-container__span">
-                    <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
-                    <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="response_expires_at">Response Expiry Time</label>
-                <span class="field-container__span">
-                    <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
-                    <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-
-            <h3 class="group-title--hidden">Runner Data</h3>
-            <div class="field-container field-container--hidden">
-                <label for="exp">Token Expiry (seconds)</label>
-                <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="language_code">Language</label>
-                <select id="language_code" name="language_code" class="qa-language-code">
-                    <option value="en">English (en)</option>
-                    <option value="cy">Cymraeg (cy)</option>
-                    <option value="ga">Gaeilge (ga)</option>
-                    <option value="eo">Ulstér Scotch (eo)</option>
-                    <option value="">&lt;not set&gt;</option>
-                </select>
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="roles">Roles</label>
-                <select id="roles" name="roles" multiple="multiple" class="qa-roles">
-                    <option value="flusher">flusher</option>
-                    <option value="dumper" selected>dumper</option>
-                </select>
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="account_service_url">Account Service URL</label>
-                <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
-            </div>
-
-            <div class="field-container field-container--hidden">
-                <label for="account_service_log_out_url">Account Service Log Out URL</label>
-                <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
-            </div>
-
-            <div class="field-container">
-                <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn button--hidden" id="submit-btn"/>
-                <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn button--hidden" id="flush-btn"/>
-            </div>
-
-        </form>
-    </div>
-</body>
-<script>
-    // uuidv4: from https://github.com/kelektiv/node-uuid
-    !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
-
-    // store fetch so it only needs to be re-done if the survey changes
-    let supplementaryDataSets = null;
-
-    function clearSurveyMetadataFields() {
-        document.querySelector('#survey_metadata_fields').innerHTML = ""
-        hideSupplementaryData()
-    }
-
-    function showSupplementaryData () {
-        document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'block');
-    }
-
-    function hideSupplementaryData () {
-        document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'none');
-    }
-
-    function showAllDivs() {
-        document.querySelectorAll("#survey_metadata, .field-container--hidden, .group-title--hidden").forEach(function (element) {
-            element.style.display = 'block';
-        });
-
-        let launchPattern = document.querySelector("#launch_pattern").value
-
-        if (launchPattern === "v1") {
-            document.querySelectorAll(".Social").forEach(function(element) {element.setAttribute("disabled", "disabled")})
-        } else {
-            document.querySelectorAll(".Social").forEach(function(element) {element.removeAttribute("disabled")})
-        }
-    }
-
-    function includeSurveyMetadataFields(schema_name, survey_type) {
-        let launchPattern = document.querySelector("#launch_pattern").value
-        let eqIdValue = schema_name.split('_')[0]
-        let formTypeValue = schema_name.split("_").slice(1).join("_")
-
-        document.querySelector('#survey_metadata_fields').style.display = "block";
-        document.querySelector('#supplementary_data').style.display = "block";
-
-        if (launchPattern === "v1") {
-            document.querySelector('#survey_metadata_fields').innerHTML = `
-                <h3>${survey_type} Survey Metadata</h3>
-                <div class="field-container">
-                    <label for="eq_id">eq_id</label>
-                    <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
                 </div>
+
+                <strong><u>Launch by Schema Name</u></strong>
                 <div class="field-container">
-                    <label for="form_type">form_type</label>
-                    <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                    <label for="schema_name">Schemas</label>
+                    <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
+                        <option selected disabled>Select Schema</option>
+
+                        {{ range $surveyType, $schemasList := .Schemas }}
+                            <optgroup label="{{ $surveyType }} Surveys">
+                                {{ range $schema := $schemasList }}
+                                    <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
+                                {{ end }}
+                            </optgroup>
+                        {{ end }}
+                    </select>
                 </div>
-            `
-        } else {
-            document.querySelector('#survey_metadata_fields').innerHTML = `
-                <h3>${survey_type} Survey Metadata</h3>
+
+                <p>----------</p>
+
+                <strong><u>Launch by Schema URL</u></strong>
+
                 <div class="field-container">
-                    <label for="form_type">form_type</label>
-                    <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                    <span class="field-container__span">
+                        <label for="schema-url-survey-type">Survey Type</label>
+                        <select name="survey-types" id="schema-url-survey-type">
+                            <option selected disabled>Select Survey Type</option>
+                            {{ range $surveyType, $schemasList := .Schemas }}
+                            <option value="{{ $surveyType }}">{{ $surveyType }}</option>
+                        {{ end }}
+                        </select>
+                    </span>
                 </div>
-            `
+
+                <div class="field-container">
+                    <span class="field-container__span">
+                        <label for="schema-url">Schema URL</label>
+                        <input id="schema-url" name="schema_url" type="text" class="qa-schema_url">
+                    </span>
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <input type="submit" onClick="displayLaunchButton(true); return loadMetadataForSchemaUrl();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
+                </div>
+
+                <p>----------</p>
+
+                <div id="survey_metadata_fields" class="metadata-fields--hidden">
+                </div>
+
+                <h3 class="group-title--hidden">Survey Metadata</h3>
+                <div id="survey_metadata" class="metadata-fields--hidden">
+                    <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
+                </div>
+
+                <h3 class="supplementary-data--hidden">Supplementary Data</h3>
+                <div class="supplementary-data--hidden" id="supplementary_data">
+                </div>
+
+                <h3 class="group-title--hidden">Required Data</h3>
+
+                <div class="field-container field-container--hidden">
+                    <label for="case_id">Case ID</label>
+                    <span class="field-container__span">
+                        <input id="case_id" name="case_id" type="text" class="qa-case_id">
+                        <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                    </span>
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="response_id">Response ID</label>
+                    <span class="field-container__span">
+                        <input id="response_id" name="response_id" type="text" class="qa-response_id">
+                        <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                    </span>
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="collection_exercise_sid">Collection Exercise SID</label>
+                    <span class="field-container__span">
+                        <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
+                        <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                    </span>
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="response_expires_at">Response Expiry Time</label>
+                    <span class="field-container__span">
+                        <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
+                        <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                    </span>
+                </div>
+
+
+                <h3 class="group-title--hidden">Runner Data</h3>
+                <div class="field-container field-container--hidden">
+                    <label for="exp">Token Expiry (seconds)</label>
+                    <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="language_code">Language</label>
+                    <select id="language_code" name="language_code" class="qa-language-code">
+                        <option value="en">English (en)</option>
+                        <option value="cy">Cymraeg (cy)</option>
+                        <option value="ga">Gaeilge (ga)</option>
+                        <option value="eo">Ulstér Scotch (eo)</option>
+                        <option value="">&lt;not set&gt;</option>
+                    </select>
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="roles">Roles</label>
+                    <select id="roles" name="roles" multiple="multiple" class="qa-roles">
+                        <option value="flusher">flusher</option>
+                        <option value="dumper" selected>dumper</option>
+                    </select>
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="account_service_url">Account Service URL</label>
+                    <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
+                </div>
+
+                <div class="field-container field-container--hidden">
+                    <label for="account_service_log_out_url">Account Service Log Out URL</label>
+                    <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
+                </div>
+
+                <div class="field-container">
+                    <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn button--hidden" id="submit-btn"/>
+                    <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn button--hidden" id="flush-btn"/>
+                </div>
+
+            </form>
+        </div>
+    </body>
+    <script>
+        // uuidv4: from https://github.com/kelektiv/node-uuid
+        !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
+
+        // store fetch so it only needs to be re-done if the survey changes
+        let supplementaryDataSets = null;
+
+        function clearSurveyMetadataFields() {
+            document.querySelector('#survey_metadata_fields').innerHTML = ""
+            hideSupplementaryData()
         }
 
-    }
-
-    function displayLaunchButton(launchBySchemaUrl) {
-        let version = document.querySelector("#launch_pattern").value
-        let schema_name = document.querySelector("#schema_name").value
-
-        if (version !== 'Select Launch Pattern' && schema_name !== "Select Schema") {
-            document.querySelector(`#submit-btn`).style.display = 'inline-block';
-            document.querySelector("#flush-btn").style.display = 'inline-block';
+        function showSupplementaryData () {
+            document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'block');
         }
 
-        if (launchBySchemaUrl === true) {
-            document.querySelector(`#submit-btn`).style.display = 'inline-block';
-        }
-    }
-
-    function clearAndDisableSchemaUrlSelection() {
-        document.querySelector("#schema-url-btn").disabled = true;
-
-        let schemaUrlElement = document.querySelector("#schema-url")
-        let surveyTypeElement = document.querySelector("#schema-url-survey-type")
-
-        surveyTypeElement.selectedIndex = 0
-        schemaUrlElement.value = ""
-        surveyTypeElement.disabled = true
-        schemaUrlElement.disabled = true
-    }
-
-    function clearAndDisableSchemaNameSelection() {
-        let schemaNameElement = document.querySelector("#schema_name")
-
-        schemaNameElement.selectedIndex = 0
-        schemaNameElement.disabled = true
-    }
-
-    function loadMetadataForSchemaName() {
-        clearAndDisableSchemaUrlSelection()
-
-        const schemaName = document.querySelector("#schema_name").value
-        const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
-
-        loadSurveyMetadata(schemaName, surveyType)
-        loadSchemaMetadata(schemaName, null)
-    }
-
-    function loadMetadataForSchemaUrl() {
-        let schemaUrl = document.querySelector("#schema-url").value
-        if (!schemaUrl || !schemaUrl.endsWith(".json")) {
-            alert("Schema URL not provided or is not valid.\n" +
-                "URL must end with '.json'")
-            return false
+        function hideSupplementaryData () {
+            document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'none');
         }
 
-        let surveyType = document.querySelector("#schema-url-survey-type").value
-        if (surveyType.toLowerCase() === "select survey type") {
-            alert("Select a Survey Type.")
-            return false
+        function showAllDivs() {
+            document.querySelectorAll("#survey_metadata, .field-container--hidden, .group-title--hidden").forEach(function (element) {
+                element.style.display = 'block';
+            });
+
+            let launchPattern = document.querySelector("#launch_pattern").value
+
+            if (launchPattern === "v1") {
+                document.querySelectorAll(".Social").forEach(function(element) {element.setAttribute("disabled", "disabled")})
+            } else {
+                document.querySelectorAll(".Social").forEach(function(element) {element.removeAttribute("disabled")})
+            }
         }
 
-        clearAndDisableSchemaNameSelection()
+        function includeSurveyMetadataFields(schema_name, survey_type) {
+            let launchPattern = document.querySelector("#launch_pattern").value
+            let eqIdValue = schema_name.split('_')[0]
+            let formTypeValue = schema_name.split("_").slice(1).join("_")
 
-        let schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+            document.querySelector('#survey_metadata_fields').style.display = "block";
+            document.querySelector('#supplementary_data').style.display = "block";
 
-        loadSurveyMetadata(schemaName, surveyType)
-        loadSchemaMetadata(schemaName, schemaUrl)
+            if (launchPattern === "v1") {
+                document.querySelector('#survey_metadata_fields').innerHTML = `
+                    <h3>${survey_type} Survey Metadata</h3>
+                    <div class="field-container">
+                        <label for="eq_id">eq_id</label>
+                        <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
+                    </div>
+                    <div class="field-container">
+                        <label for="form_type">form_type</label>
+                        <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                    </div>
+                `
+            } else {
+                document.querySelector('#survey_metadata_fields').innerHTML = `
+                    <h3>${survey_type} Survey Metadata</h3>
+                    <div class="field-container">
+                        <label for="form_type">form_type</label>
+                        <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                    </div>
+                `
+            }
 
-        displayLaunchButton(false)
-
-        return false
-    }
-
-    function loadSurveyMetadata(schema_name, survey_type) {
-        if (survey_type.toLowerCase() === "test" || survey_type.toLowerCase() === "social") {
-            clearSurveyMetadataFields()
-        } else {
-            includeSurveyMetadataFields(schema_name, survey_type)
         }
-    }
 
-    async function getDataAsync(queryParam) {
-        return new Promise((resolve, reject) => {
-            let xhttp = new XMLHttpRequest();
-            xhttp.onreadystatechange = function() {
-                if (this.readyState === 4) {
-                    if (this.status === 200) {
-                        resolve(JSON.parse(this.responseText))
-                    } else {
-                        alert(`Request failed. ${this.responseText}`)
-                        reject(`Request failed. ${this.responseText}`)
-                    }
-                }
-            };
-            xhttp.open("GET", queryParam, true);
-            xhttp.send();
-        })
-    }
+        function displayLaunchButton(launchBySchemaUrl) {
+            let version = document.querySelector("#launch_pattern").value
+            let schema_name = document.querySelector("#schema_name").value
 
-    function getLabelFor(fieldName){
-        return `<label for="${fieldName}">${fieldName}</label>`
-    }
-
-    function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
-        const value = defaultValue ? `value="${defaultValue}"` : ''
-        const readOnly = isReadOnly ? 'readonly' : ''
-        return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
-    }
-
-    async function loadSDSDatasetMetadata(survey_id, period_id) {
-        if (survey_id && period_id) {
-            const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
-            return await getDataAsync(sds_dataset_metadata_url)
-        }
-        return null
-    }
-
-    function handleNoSupplementaryData() {
-
-        hideSupplementaryData()
-        document.querySelector("#sds_dataset_id").innerHTML = null
-        document.querySelector(`#submit-btn`).style.display = 'none';
-        document.querySelector("#flush-btn").style.display = 'none';
-
-    }
-
-    function updateSDSDropdown() {
-        const surveyId = document.getElementById("survey_id")?.value;
-        const periodId = document.getElementById("period_id")?.value;
-        loadSDSDatasetMetadata(surveyId, periodId)
-            .then(sds_metadata_response => {
-                if (sds_metadata_response?.length) {
-                    supplementaryDataSets = sds_metadata_response
-                    showSupplementaryData()
-                    document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
-                        `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
-                        .join("");
-                    loadSupplementaryDataInfo()
-                    displayLaunchButton(false)
-                } else {
-                    handleNoSupplementaryData()
-                }
-            })
-            .catch(_ => handleNoSupplementaryData())
-    }
-
-    function loadSchemaMetadata(schemaName, schemaUrl) {
-        let survey_data_url = `/survey-data?schema_name=${schemaName}`
-        if (schemaUrl ){
-            survey_data_url += `&schema_url=${schemaUrl}`
-        }
-        hideSupplementaryData()
-        getDataAsync(survey_data_url)
-            .then(schema_response => {
-                document.querySelector("#survey_metadata").innerHTML = "";
-                document.querySelector("#survey_metadata").innerHTML = "";
-
-                if (schema_response.metadata.length > 0) {
-                    document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
-
-                        const fieldName = metadataField["name"]
-                        let defaultValue = metadataField['default'];
-
-                        if (metadataField['type'] === "date") {
-                            const currentDate = new Date()
-                            // format as yyyy-MM-dd
-                            defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
-                        }
-
-                        return `<div class="field-container">${getLabelFor(fieldName)}${
-                            (() => {
-                                if (metadataField['type'] === "boolean") {
-                                    return getInputField(fieldName, "checkbox");
-                                }
-                                else if (metadataField['type'] === "uuid") {
-                                    return (
-                                        `<span  class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
-                                        `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
-                                        `</span>`
-                                    );
-                                }
-                                else if (fieldName === "survey_id" || fieldName === "period_id") {
-                                    return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
-                                }
-                                else if (fieldName === "sds_dataset_id") {
-                                    return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
-                                }
-                                else {
-                                    return getInputField(fieldName, "text", defaultValue)
-                                }
-                            })()
-                        }</div>`
-                    }).join("")
-                    updateSDSDropdown()
-                } else {
-                    document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
-                }
-
+            if (schema_name !== "Select Schema") {
+                document.querySelector(`#submit-btn`).style.display = 'inline-block';
                 document.querySelector("#flush-btn").style.display = 'inline-block';
+            }
+
+            if (launchBySchemaUrl === true) {
+                document.querySelector(`#submit-btn`).style.display = 'inline-block';
+            }
+        }
+
+        function clearAndDisableSchemaUrlSelection() {
+            document.querySelector("#schema-url-btn").disabled = true;
+
+            let schemaUrlElement = document.querySelector("#schema-url")
+            let surveyTypeElement = document.querySelector("#schema-url-survey-type")
+
+            surveyTypeElement.selectedIndex = 0
+            schemaUrlElement.value = ""
+            surveyTypeElement.disabled = true
+            schemaUrlElement.disabled = true
+        }
+
+        function clearAndDisableSchemaNameSelection() {
+            let schemaNameElement = document.querySelector("#schema_name")
+
+            schemaNameElement.selectedIndex = 0
+            schemaNameElement.disabled = true
+        }
+
+        function loadMetadataForSchemaName() {
+            clearAndDisableSchemaUrlSelection()
+
+            const schemaName = document.querySelector("#schema_name").value
+            const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
+
+            loadSurveyMetadata(schemaName, surveyType)
+            loadSchemaMetadata(schemaName, null)
+        }
+
+        function loadMetadataForSchemaUrl() {
+            let schemaUrl = document.querySelector("#schema-url").value
+            if (!schemaUrl || !schemaUrl.endsWith(".json")) {
+                alert("Schema URL not provided or is not valid.\n" +
+                    "URL must end with '.json'")
+                return false
+            }
+
+            let surveyType = document.querySelector("#schema-url-survey-type").value
+            if (surveyType.toLowerCase() === "select survey type") {
+                alert("Select a Survey Type.")
+                return false
+            }
+
+            clearAndDisableSchemaNameSelection()
+
+            let schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+
+            loadSurveyMetadata(schemaName, surveyType)
+            loadSchemaMetadata(schemaName, schemaUrl)
+
+            displayLaunchButton(false)
+
+            return false
+        }
+
+        function loadSurveyMetadata(schema_name, survey_type) {
+            if (survey_type.toLowerCase() === "test" || survey_type.toLowerCase() === "social") {
+                clearSurveyMetadataFields()
+            } else {
+                includeSurveyMetadataFields(schema_name, survey_type)
+            }
+        }
+
+        async function getDataAsync(queryParam) {
+            return new Promise((resolve, reject) => {
+                let xhttp = new XMLHttpRequest();
+                xhttp.onreadystatechange = function() {
+                    if (this.readyState === 4) {
+                        if (this.status === 200) {
+                            resolve(JSON.parse(this.responseText))
+                        } else {
+                            alert(`Request failed. ${this.responseText}`)
+                            reject(`Request failed. ${this.responseText}`)
+                        }
+                    }
+                };
+                xhttp.open("GET", queryParam, true);
+                xhttp.send();
             })
-            .catch(_ => {
-                document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
-            })
-    }
-
-    function loadSupplementaryDataInfo () {
-        const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
-        const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
-        if (selectedDataset) {
-            const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
-
-            document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
-                key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
-            ).join('')
         }
-    }
 
-    function uuid(el_id) {
-        document.querySelector(`#${el_id}`).value = uuidv4();
-    }
-
-    function numericId() {
-        let result = '';
-        let chars = '0123456789';
-        for (let i = 16; i > 0; --i) {
-            result += chars[Math.round(Math.random() * (chars.length - 1))];
+        function getLabelFor(fieldName){
+            return `<label for="${fieldName}">${fieldName}</label>`
         }
-        document.querySelector(`#response_id`).value = result;
-    }
 
-    function setResponseExpiry(days_offset=7) {
-        let dt = new Date();
-        dt.setDate(dt.getDate()+days_offset)
-        document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
-    }
-
-    function validateForm() {
-        validateResponseExpiresAt();
-    }
-
-    function validateResponseExpiresAt() {
-        let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
-        if (isNaN(responseExpiresAt)) {
-            document.querySelector('#response_expires_at').remove()
+        function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
+            const value = defaultValue ? `value="${defaultValue}"` : ''
+            const readOnly = isReadOnly ? 'readonly' : ''
+            return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
         }
-    }
 
-    function resetDropdowns() {
-        document.getElementById('launch_pattern').selectedIndex = -1;
-        document.getElementById('schema_name').selectedIndex = -1;
-        document.getElementById('schema-url-survey-type').selectedIndex = -1;
-    }
+        async function loadSDSDatasetMetadata(survey_id, period_id) {
+            if (survey_id && period_id) {
+                const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
+                return await getDataAsync(sds_dataset_metadata_url)
+            }
+            return null
+        }
 
-    uuid('collection_exercise_sid');
-    uuid('case_id');
-    numericId();
-    setResponseExpiry();
+        function handleNoSupplementaryData() {
 
-</script>
+            hideSupplementaryData()
+            document.querySelector("#sds_dataset_id").innerHTML = null
+            document.querySelector(`#submit-btn`).style.display = 'none';
+            document.querySelector("#flush-btn").style.display = 'none';
 
-{{end}}
+        }
+
+        function updateSDSDropdown() {
+            const surveyId = document.getElementById("survey_id")?.value;
+            const periodId = document.getElementById("period_id")?.value;
+            loadSDSDatasetMetadata(surveyId, periodId)
+                .then(sds_metadata_response => {
+                    if (sds_metadata_response?.length) {
+                        supplementaryDataSets = sds_metadata_response
+                        showSupplementaryData()
+                        document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
+                            `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
+                            .join("");
+                        loadSupplementaryDataInfo()
+                        displayLaunchButton(false)
+                    } else {
+                        handleNoSupplementaryData()
+                    }
+                })
+                .catch(_ => handleNoSupplementaryData())
+        }
+
+        function loadSchemaMetadata(schemaName, schemaUrl) {
+            let survey_data_url = `/survey-data?schema_name=${schemaName}`
+            if (schemaUrl ){
+                survey_data_url += `&schema_url=${schemaUrl}`
+            }
+            hideSupplementaryData()
+            getDataAsync(survey_data_url)
+                .then(schema_response => {
+                    document.querySelector("#survey_metadata").innerHTML = "";
+                    document.querySelector("#survey_metadata").innerHTML = "";
+
+                    if (schema_response.metadata.length > 0) {
+                        document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
+
+                            const fieldName = metadataField["name"]
+                            let defaultValue = metadataField['default'];
+
+                            if (metadataField['type'] === "date") {
+                                const currentDate = new Date()
+                                // format as yyyy-MM-dd
+                                defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
+                            }
+
+                            return `<div class="field-container">${getLabelFor(fieldName)}${
+                                (() => {
+                                    if (metadataField['type'] === "boolean") {
+                                        return getInputField(fieldName, "checkbox");
+                                    }
+                                    else if (metadataField['type'] === "uuid") {
+                                        return (
+                                            `<span  class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
+                                            `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
+                                            `</span>`
+                                        );
+                                    }
+                                    else if (fieldName === "survey_id" || fieldName === "period_id") {
+                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
+                                    }
+                                    else if (fieldName === "sds_dataset_id") {
+                                        return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
+                                    }
+                                    else {
+                                        return getInputField(fieldName, "text", defaultValue)
+                                    }
+                                })()
+                            }</div>`
+                        }).join("")
+                        updateSDSDropdown()
+                    } else {
+                        document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                    }
+
+                    document.querySelector("#flush-btn").style.display = 'inline-block';
+                })
+                .catch(_ => {
+                    document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
+                })
+        }
+
+        function loadSupplementaryDataInfo () {
+            const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
+            const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
+            if (selectedDataset) {
+                const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
+
+                document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
+                    key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
+                ).join('')
+            }
+        }
+
+        function uuid(el_id) {
+            document.querySelector(`#${el_id}`).value = uuidv4();
+        }
+
+        function numericId() {
+            let result = '';
+            let chars = '0123456789';
+            for (let i = 16; i > 0; --i) {
+                result += chars[Math.round(Math.random() * (chars.length - 1))];
+            }
+            document.querySelector(`#response_id`).value = result;
+        }
+
+        function setResponseExpiry(days_offset=7) {
+            let dt = new Date();
+            dt.setDate(dt.getDate()+days_offset)
+            document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
+        }
+
+        function validateForm() {
+            validateResponseExpiresAt();
+        }
+
+        function validateResponseExpiresAt() {
+            let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
+            if (isNaN(responseExpiresAt)) {
+                document.querySelector('#response_expires_at').remove()
+            }
+        }
+
+        function resetDropdowns() {
+            document.getElementById('launch_pattern').selectedIndex = -1;
+            document.getElementById('schema_name').selectedIndex = -1;
+            document.getElementById('schema-url-survey-type').selectedIndex = -1;
+        }
+
+        uuid('collection_exercise_sid');
+        uuid('case_id');
+        numericId();
+        setResponseExpiry();
+        showAllDivs();
+
+    </script>
+
+{{ end }}

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -10,7 +10,7 @@
                 <strong><u>Launch Pattern</u></strong>
                 <div class="field-container">
                     <label for="launch_pattern">Version</label>
-                    <select id="launch_pattern" name="launch_version" class="qa-select-launch-version">
+                    <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName();">
                         <option value="v1">v1</option>
                         <option value="v2" selected="selected">v2</option>
                     </select>
@@ -35,7 +35,6 @@
                 <p>----------</p>
 
                 <strong><u>Launch by Schema URL</u></strong>
-
                 <div class="field-container">
                     <span class="field-container__span">
                         <label for="schema-url-survey-type">Survey Type</label>
@@ -175,14 +174,6 @@
             document.querySelectorAll("#survey_metadata, .field-container--hidden, .group-title--hidden").forEach(function (element) {
                 element.style.display = 'block';
             });
-
-            let launchPattern = document.querySelector("#launch_pattern").value
-
-            if (launchPattern === "v1") {
-                document.querySelectorAll(".Social").forEach(function(element) {element.setAttribute("disabled", "disabled")})
-            } else {
-                document.querySelectorAll(".Social").forEach(function(element) {element.removeAttribute("disabled")})
-            }
         }
 
         function includeSurveyMetadataFields(schema_name, survey_type) {
@@ -203,16 +194,14 @@
                     <div class="field-container">
                         <label for="form_type">form_type</label>
                         <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
-                    </div>
-                `
+                    </div>`
             } else {
                 document.querySelector('#survey_metadata_fields').innerHTML = `
                     <h3>${survey_type} Survey Metadata</h3>
                     <div class="field-container">
                         <label for="form_type">form_type</label>
                         <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
-                    </div>
-                `
+                    </div>`
             }
 
         }
@@ -250,13 +239,17 @@
         }
 
         function loadMetadataForSchemaName() {
-            clearAndDisableSchemaUrlSelection()
+            let schema_name = document.querySelector("#schema_name").value
 
-            const schemaName = document.querySelector("#schema_name").value
-            const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
+            if (schema_name !== "Select Schema") {
+                clearAndDisableSchemaUrlSelection()
 
-            loadSurveyMetadata(schemaName, surveyType)
-            loadSchemaMetadata(schemaName, null)
+                const schemaName = document.querySelector("#schema_name").value
+                const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
+
+                loadSurveyMetadata(schemaName, surveyType)
+                loadSchemaMetadata(schemaName, null)
+            }
         }
 
         function loadMetadataForSchemaUrl() {
@@ -332,7 +325,6 @@
         function handleNoSupplementaryData() {
 
             hideSupplementaryData()
-            document.querySelector("#sds_dataset_id").innerHTML = null
             document.querySelector(`#submit-btn`).style.display = 'none';
             document.querySelector("#flush-btn").style.display = 'none';
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -2,469 +2,469 @@
 
 {{ define "body" }}
 
-    <body onbeforeunload='resetDropdowns();'>
-        <h1>Launch a survey</h1>
-        <div>
-            <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
+<body onbeforeunload='resetDropdowns();'>
+    <h1>Launch a survey</h1>
+    <div>
+        <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
 
-                <strong><u>Launch Pattern</u></strong>
-                <div class="field-container">
-                    <label for="launch_pattern">Version</label>
-                    <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
-                        <option value="v1">v1</option>
-                        <option value="v2" selected="selected">v2</option>
-                    </select>
-                </div>
+            <strong><u>Launch Pattern</u></strong>
+            <div class="field-container">
+                <label for="launch_pattern">Version</label>
+                <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
+                    <option value="v1">v1</option>
+                    <option value="v2" selected="selected">v2</option>
+                </select>
+            </div>
 
-                <strong><u>Launch by Schema Name</u></strong>
-                <div class="field-container">
-                    <label for="schema_name">Schemas</label>
-                    <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
-                        <option selected disabled>Select Schema</option>
+            <strong><u>Launch by Schema Name</u></strong>
+            <div class="field-container">
+                <label for="schema_name">Schemas</label>
+                <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
+                    <option selected disabled>Select Schema</option>
 
+                    {{ range $surveyType, $schemasList := .Schemas }}
+                        <optgroup label="{{ $surveyType }} Surveys">
+                            {{ range $schema := $schemasList }}
+                                <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
+                            {{ end }}
+                        </optgroup>
+                    {{ end }}
+                </select>
+            </div>
+
+            <p>----------</p>
+
+            <strong><u>Launch by Schema URL</u></strong>
+            <div class="field-container">
+                <span class="field-container__span">
+                    <label for="schema-url-survey-type">Survey Type</label>
+                    <select name="survey-types" id="schema-url-survey-type">
+                        <option selected disabled>Select Survey Type</option>
                         {{ range $surveyType, $schemasList := .Schemas }}
-                            <optgroup label="{{ $surveyType }} Surveys">
-                                {{ range $schema := $schemasList }}
-                                    <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
-                                {{ end }}
-                            </optgroup>
-                        {{ end }}
+                        <option value="{{ $surveyType }}">{{ $surveyType }}</option>
+                    {{ end }}
                     </select>
+                </span>
+            </div>
+
+            <div class="field-container">
+                <span class="field-container__span">
+                    <label for="schema-url">Schema URL</label>
+                    <input id="schema-url" name="schema_url" type="text" class="qa-schema_url">
+                </span>
+            </div>
+
+            <div class="field-container">
+                <input type="submit" onClick="displayLaunchButton(true); return loadMetadataForSchemaUrl();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
+            </div>
+
+            <p>----------</p>
+
+            <div id="survey_metadata_fields">
+            </div>
+
+            <h3>Survey Metadata</h3>
+            <div id="survey_metadata">
+                <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
+            </div>
+
+            <div class="supplementary-data supplementary-data--hidden">
+                <h3>Supplementary Data</h3>
+                <div id="supplementary_data">
                 </div>
+            </div>
 
-                <p>----------</p>
+            <h3>Required Data</h3>
 
-                <strong><u>Launch by Schema URL</u></strong>
-                <div class="field-container">
-                    <span class="field-container__span">
-                        <label for="schema-url-survey-type">Survey Type</label>
-                        <select name="survey-types" id="schema-url-survey-type">
-                            <option selected disabled>Select Survey Type</option>
-                            {{ range $surveyType, $schemasList := .Schemas }}
-                            <option value="{{ $surveyType }}">{{ $surveyType }}</option>
-                        {{ end }}
-                        </select>
-                    </span>
-                </div>
+            <div class="field-container">
+                <label for="case_id">Case ID</label>
+                <span class="field-container__span">
+                    <input id="case_id" name="case_id" type="text" class="qa-case_id">
+                    <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
 
-                <div class="field-container">
-                    <span class="field-container__span">
-                        <label for="schema-url">Schema URL</label>
-                        <input id="schema-url" name="schema_url" type="text" class="qa-schema_url">
-                    </span>
-                </div>
+            <div class="field-container">
+                <label for="response_id">Response ID</label>
+                <span class="field-container__span">
+                    <input id="response_id" name="response_id" type="text" class="qa-response_id">
+                    <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
 
-                <div class="field-container">
-                    <input type="submit" onClick="displayLaunchButton(true); return loadMetadataForSchemaUrl();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
-                </div>
+            <div class="field-container">
+                <label for="collection_exercise_sid">Collection Exercise SID</label>
+                <span class="field-container__span">
+                    <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
+                    <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
 
-                <p>----------</p>
-
-                <div id="survey_metadata_fields">
-                </div>
-
-                <h3>Survey Metadata</h3>
-                <div id="survey_metadata">
-                    <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
-                </div>
-
-                <div class="supplementary-data supplementary-data--hidden">
-                    <h3>Supplementary Data</h3>
-                    <div id="supplementary_data">
-                    </div>
-                </div>
-
-                <h3>Required Data</h3>
-
-                <div class="field-container">
-                    <label for="case_id">Case ID</label>
-                    <span class="field-container__span">
-                        <input id="case_id" name="case_id" type="text" class="qa-case_id">
-                        <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                    </span>
-                </div>
-
-                <div class="field-container">
-                    <label for="response_id">Response ID</label>
-                    <span class="field-container__span">
-                        <input id="response_id" name="response_id" type="text" class="qa-response_id">
-                        <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                    </span>
-                </div>
-
-                <div class="field-container">
-                    <label for="collection_exercise_sid">Collection Exercise SID</label>
-                    <span class="field-container__span">
-                        <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
-                        <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                    </span>
-                </div>
-
-                <div class="field-container">
-                    <label for="response_expires_at">Response Expiry Time</label>
-                    <span class="field-container__span">
-                        <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
-                        <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                    </span>
-                </div>
+            <div class="field-container">
+                <label for="response_expires_at">Response Expiry Time</label>
+                <span class="field-container__span">
+                    <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
+                    <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
 
 
-                <h3>Runner Data</h3>
-                <div class="field-container">
-                    <label for="exp">Token Expiry (seconds)</label>
-                    <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
-                </div>
+            <h3>Runner Data</h3>
+            <div class="field-container">
+                <label for="exp">Token Expiry (seconds)</label>
+                <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
+            </div>
 
-                <div class="field-container">
-                    <label for="language_code">Language</label>
-                    <select id="language_code" name="language_code" class="qa-language-code">
-                        <option value="en">English (en)</option>
-                        <option value="cy">Cymraeg (cy)</option>
-                        <option value="ga">Gaeilge (ga)</option>
-                        <option value="eo">Ulstér Scotch (eo)</option>
-                        <option value="">&lt;not set&gt;</option>
-                    </select>
-                </div>
+            <div class="field-container">
+                <label for="language_code">Language</label>
+                <select id="language_code" name="language_code" class="qa-language-code">
+                    <option value="en">English (en)</option>
+                    <option value="cy">Cymraeg (cy)</option>
+                    <option value="ga">Gaeilge (ga)</option>
+                    <option value="eo">Ulstér Scotch (eo)</option>
+                    <option value="">&lt;not set&gt;</option>
+                </select>
+            </div>
 
-                <div class="field-container">
-                    <label for="roles">Roles</label>
-                    <select id="roles" name="roles" multiple="multiple" class="qa-roles">
-                        <option value="flusher">flusher</option>
-                        <option value="dumper" selected>dumper</option>
-                    </select>
-                </div>
+            <div class="field-container">
+                <label for="roles">Roles</label>
+                <select id="roles" name="roles" multiple="multiple" class="qa-roles">
+                    <option value="flusher">flusher</option>
+                    <option value="dumper" selected>dumper</option>
+                </select>
+            </div>
 
-                <div class="field-container">
-                    <label for="account_service_url">Account Service URL</label>
-                    <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
-                </div>
+            <div class="field-container">
+                <label for="account_service_url">Account Service URL</label>
+                <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
+            </div>
 
-                <div class="field-container">
-                    <label for="account_service_log_out_url">Account Service Log Out URL</label>
-                    <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
-                </div>
+            <div class="field-container">
+                <label for="account_service_log_out_url">Account Service Log Out URL</label>
+                <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
+            </div>
 
-                <div class="field-container">
-                    <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn"/>
-                    <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
-                </div>
+            <div class="field-container">
+                <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn"/>
+                <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
+            </div>
 
-            </form>
-        </div>
-    </body>
-    <script>
-        // uuidv4: from https://github.com/kelektiv/node-uuid
-        !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
+        </form>
+    </div>
+</body>
+<script>
+    // uuidv4: from https://github.com/kelektiv/node-uuid
+    !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
-        // store fetch so it only needs to be re-done if the survey changes
-        let supplementaryDataSets = null;
+    // store fetch so it only needs to be re-done if the survey changes
+    let supplementaryDataSets = null;
 
-        function clearSurveyMetadataFields() {
-            document.querySelector('#survey_metadata_fields').innerHTML = ""
-            toggleSupplementaryData("hide");
+    function clearSurveyMetadataFields() {
+        document.querySelector('#survey_metadata_fields').innerHTML = ""
+        toggleSupplementaryData("hide");
+    }
+
+    function toggleSupplementaryData(showHide) {
+        if (showHide == "hide") {
+            document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
+        } else if (showHide == "show") {
+            document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
         }
+    }
 
-        function toggleSupplementaryData(showHide) {
-            if (showHide == "hide") {
-                document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
-            } else if (showHide == "show") {
-                document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
+    function toggleSubmitFlushButtons(showHide, justSubmit = false) {
+        if (showHide == "hide") {
+            document.querySelector("#submit-btn").classList.add("btn--hidden");
+            if (!justSubmit) {
+                document.querySelector("#flush-btn").classList.add("btn--hidden");
             }
         }
-
-        function toggleSubmitFlushButtons(showHide, justSubmit = false) {
-            if (showHide == "hide") {
-                document.querySelector("#submit-btn").classList.add("btn--hidden");
-                if (!justSubmit) {
-                    document.querySelector("#flush-btn").classList.add("btn--hidden");
-                }
-            }
-            if (showHide == "show") {
-                document.querySelector("#submit-btn").classList.remove("btn--hidden");
-                if (!justSubmit) {
-                    document.querySelector("#flush-btn").classList.remove("btn--hidden");
-                }
+        if (showHide == "show") {
+            document.querySelector("#submit-btn").classList.remove("btn--hidden");
+            if (!justSubmit) {
+                document.querySelector("#flush-btn").classList.remove("btn--hidden");
             }
         }
+    }
 
-        function includeSurveyMetadataFields(schema_name, survey_type) {
-            let launchPattern = document.querySelector("#launch_pattern").value
-            let eqIdValue = schema_name.split('_')[0]
-            let formTypeValue = schema_name.split("_").slice(1).join("_")
+    function includeSurveyMetadataFields(schema_name, survey_type) {
+        let launchPattern = document.querySelector("#launch_pattern").value
+        let eqIdValue = schema_name.split('_')[0]
+        let formTypeValue = schema_name.split("_").slice(1).join("_")
 
-            if (launchPattern === "v1") {
-                document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
-                    <div class="field-container">
-                        <label for="eq_id">eq_id</label>
-                        <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
-                    </div>
-                    <div class="field-container">
-                        <label for="form_type">form_type</label>
-                        <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
-                    </div>`
-            } else {
-                document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
-                    <div class="field-container">
-                        <label for="form_type">form_type</label>
-                        <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
-                    </div>`
-            }
-
-            toggleSupplementaryData("show");
-            document.querySelector('#survey_metadata_fields').classList.remove("supplementary-data--hidden");
-
+        if (launchPattern === "v1") {
+            document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
+                <div class="field-container">
+                    <label for="eq_id">eq_id</label>
+                    <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
+                </div>
+                <div class="field-container">
+                    <label for="form_type">form_type</label>
+                    <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                </div>`
+        } else {
+            document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
+                <div class="field-container">
+                    <label for="form_type">form_type</label>
+                    <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                </div>`
         }
 
-        function displayLaunchButton(launchBySchemaUrl) {
-            let schema_name = document.querySelector("#schema_name").value
+        toggleSupplementaryData("show");
+        document.querySelector('#survey_metadata_fields').classList.remove("supplementary-data--hidden");
 
-            if (schema_name !== "Select Schema") {
-                toggleSubmitFlushButtons("show");
-            }
+    }
 
-            if (launchBySchemaUrl === true) {
-                toggleSubmitFlushButtons("show", true);
-            }
+    function displayLaunchButton(launchBySchemaUrl) {
+        let schema_name = document.querySelector("#schema_name").value
+
+        if (schema_name !== "Select Schema") {
+            toggleSubmitFlushButtons("show");
         }
 
-        function clearAndDisableSchemaUrlSelection() {
-            document.querySelector("#schema-url-btn").disabled = true;
-
-            let schemaUrlElement = document.querySelector("#schema-url")
-            let surveyTypeElement = document.querySelector("#schema-url-survey-type")
-
-            surveyTypeElement.selectedIndex = 0
-            schemaUrlElement.value = ""
-            surveyTypeElement.disabled = true
-            schemaUrlElement.disabled = true
+        if (launchBySchemaUrl === true) {
+            toggleSubmitFlushButtons("show", true);
         }
+    }
 
-        function clearAndDisableSchemaNameSelection() {
-            let schemaNameElement = document.querySelector("#schema_name")
+    function clearAndDisableSchemaUrlSelection() {
+        document.querySelector("#schema-url-btn").disabled = true;
 
-            schemaNameElement.selectedIndex = 0
-            schemaNameElement.disabled = true
-        }
+        let schemaUrlElement = document.querySelector("#schema-url")
+        let surveyTypeElement = document.querySelector("#schema-url-survey-type")
 
-        function loadMetadataForSchemaName() {
-            let schema_name = document.querySelector("#schema_name").value
+        surveyTypeElement.selectedIndex = 0
+        schemaUrlElement.value = ""
+        surveyTypeElement.disabled = true
+        schemaUrlElement.disabled = true
+    }
 
-            if (schema_name !== "Select Schema") {
-                clearAndDisableSchemaUrlSelection()
+    function clearAndDisableSchemaNameSelection() {
+        let schemaNameElement = document.querySelector("#schema_name")
 
-                const schemaName = document.querySelector("#schema_name").value
-                const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
+        schemaNameElement.selectedIndex = 0
+        schemaNameElement.disabled = true
+    }
 
-                loadSurveyMetadata(schemaName, surveyType)
-                loadSchemaMetadata(schemaName, null)
-            }
-        }
+    function loadMetadataForSchemaName() {
+        let schema_name = document.querySelector("#schema_name").value
 
-        function loadMetadataForSchemaUrl() {
-            let schemaUrl = document.querySelector("#schema-url").value
-            if (!schemaUrl || !schemaUrl.endsWith(".json")) {
-                alert("Schema URL not provided or is not valid.\n" +
-                    "URL must end with '.json'")
-                return false
-            }
+        if (schema_name !== "Select Schema") {
+            clearAndDisableSchemaUrlSelection()
 
-            let surveyType = document.querySelector("#schema-url-survey-type").value
-            if (surveyType.toLowerCase() === "select survey type") {
-                alert("Select a Survey Type.")
-                return false
-            }
-
-            clearAndDisableSchemaNameSelection()
-
-            let schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+            const schemaName = document.querySelector("#schema_name").value
+            const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType
 
             loadSurveyMetadata(schemaName, surveyType)
-            loadSchemaMetadata(schemaName, schemaUrl)
+            loadSchemaMetadata(schemaName, null)
+        }
+    }
 
-            displayLaunchButton(false)
-
+    function loadMetadataForSchemaUrl() {
+        let schemaUrl = document.querySelector("#schema-url").value
+        if (!schemaUrl || !schemaUrl.endsWith(".json")) {
+            alert("Schema URL not provided or is not valid.\n" +
+                "URL must end with '.json'")
             return false
         }
 
-        function loadSurveyMetadata(schema_name, survey_type) {
-            if (survey_type.toLowerCase() === "test" || survey_type.toLowerCase() === "social") {
-                clearSurveyMetadataFields()
-            } else {
-                includeSurveyMetadataFields(schema_name, survey_type)
-            }
+        let surveyType = document.querySelector("#schema-url-survey-type").value
+        if (surveyType.toLowerCase() === "select survey type") {
+            alert("Select a Survey Type.")
+            return false
         }
 
-        async function getDataAsync(queryParam) {
-            return new Promise((resolve, reject) => {
-                let xhttp = new XMLHttpRequest();
-                xhttp.onreadystatechange = function() {
-                    if (this.readyState === 4) {
-                        if (this.status === 200) {
-                            resolve(JSON.parse(this.responseText))
-                        } else {
-                            alert(`Request failed. ${this.responseText}`)
-                            reject(`Request failed. ${this.responseText}`)
-                        }
-                    }
-                };
-                xhttp.open("GET", queryParam, true);
-                xhttp.send();
-            })
+        clearAndDisableSchemaNameSelection()
+
+        let schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+
+        loadSurveyMetadata(schemaName, surveyType)
+        loadSchemaMetadata(schemaName, schemaUrl)
+
+        displayLaunchButton(false)
+
+        return false
+    }
+
+    function loadSurveyMetadata(schema_name, survey_type) {
+        if (survey_type.toLowerCase() === "test" || survey_type.toLowerCase() === "social") {
+            clearSurveyMetadataFields()
+        } else {
+            includeSurveyMetadataFields(schema_name, survey_type)
         }
+    }
 
-        function getLabelFor(fieldName){
-            return `<label for="${fieldName}">${fieldName}</label>`
-        }
-
-        function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
-            const value = defaultValue ? `value="${defaultValue}"` : ''
-            const readOnly = isReadOnly ? 'readonly' : ''
-            return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
-        }
-
-        async function loadSDSDatasetMetadata(survey_id, period_id) {
-            if (survey_id && period_id) {
-                const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
-                return await getDataAsync(sds_dataset_metadata_url)
-            }
-            return null
-        }
-
-        function handleNoSupplementaryData() {
-            toggleSupplementaryData("hide");
-            toggleSubmitFlushButtons("hide");
-        }
-
-        function updateSDSDropdown() {
-            const surveyId = document.getElementById("survey_id")?.value;
-            const periodId = document.getElementById("period_id")?.value;
-            loadSDSDatasetMetadata(surveyId, periodId)
-                .then(sds_metadata_response => {
-                    if (sds_metadata_response?.length) {
-                        supplementaryDataSets = sds_metadata_response
-                        toggleSupplementaryData("show");
-                        toggleSubmitFlushButtons("show");
-                        document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
-                            `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
-                            .join("");
-                        loadSupplementaryDataInfo();
-                        displayLaunchButton(false);
-                    } else if (document.querySelector("#sds_dataset_id")) {
-                        document.querySelector("#sds_dataset_id").innerHTML = "";
-                        handleNoSupplementaryData();
-                    }
-                })
-                .catch(_ => {
-                    handleNoSupplementaryData();
-                })
-        }
-
-        function loadSchemaMetadata(schemaName, schemaUrl) {
-            let survey_data_url = `/survey-data?schema_name=${schemaName}`
-            if (schemaUrl ){
-                survey_data_url += `&schema_url=${schemaUrl}`
-            }
-            toggleSupplementaryData("hide");
-            getDataAsync(survey_data_url)
-                .then(schema_response => {
-                    document.querySelector("#survey_metadata").innerHTML = "";
-                    document.querySelector("#survey_metadata").innerHTML = "";
-
-                    if (schema_response.metadata.length > 0) {
-                        document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
-
-                            const fieldName = metadataField["name"]
-                            const defaultValue = metadataField['default'];
-
-                            return `<div class="field-container">${getLabelFor(fieldName)}${
-                                (() => {
-                                    if (metadataField['type'] === "boolean") {
-                                        return getInputField(fieldName, "checkbox");
-                                    }
-                                    else if (metadataField['type'] === "uuid") {
-                                        return (
-                                            `<span class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
-                                            `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
-                                            `</span>`
-                                        );
-                                    }
-                                    else if (fieldName === "survey_id" || fieldName === "period_id") {
-                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
-                                    }
-                                    else if (fieldName === "sds_dataset_id") {
-                                        return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
-                                    }
-                                    else {
-                                        return getInputField(fieldName, "text", defaultValue)
-                                    }
-                                })()
-                            }</div>`
-                        }).join("")
-                        updateSDSDropdown()
+    async function getDataAsync(queryParam) {
+        return new Promise((resolve, reject) => {
+            let xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function() {
+                if (this.readyState === 4) {
+                    if (this.status === 200) {
+                        resolve(JSON.parse(this.responseText))
                     } else {
-                        document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                        alert(`Request failed. ${this.responseText}`)
+                        reject(`Request failed. ${this.responseText}`)
                     }
+                }
+            };
+            xhttp.open("GET", queryParam, true);
+            xhttp.send();
+        })
+    }
 
+    function getLabelFor(fieldName){
+        return `<label for="${fieldName}">${fieldName}</label>`
+    }
+
+    function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
+        const value = defaultValue ? `value="${defaultValue}"` : ''
+        const readOnly = isReadOnly ? 'readonly' : ''
+        return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
+    }
+
+    async function loadSDSDatasetMetadata(survey_id, period_id) {
+        if (survey_id && period_id) {
+            const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
+            return await getDataAsync(sds_dataset_metadata_url)
+        }
+        return null
+    }
+
+    function handleNoSupplementaryData() {
+        toggleSupplementaryData("hide");
+        toggleSubmitFlushButtons("hide");
+    }
+
+    function updateSDSDropdown() {
+        const surveyId = document.getElementById("survey_id")?.value;
+        const periodId = document.getElementById("period_id")?.value;
+        loadSDSDatasetMetadata(surveyId, periodId)
+            .then(sds_metadata_response => {
+                if (sds_metadata_response?.length) {
+                    supplementaryDataSets = sds_metadata_response
+                    toggleSupplementaryData("show");
                     toggleSubmitFlushButtons("show");
-                })
-                .catch(_ => {
-                    document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
-                })
+                    document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
+                        `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
+                        .join("");
+                    loadSupplementaryDataInfo();
+                    displayLaunchButton(false);
+                } else if (document.querySelector("#sds_dataset_id")) {
+                    document.querySelector("#sds_dataset_id").innerHTML = "";
+                    handleNoSupplementaryData();
+                }
+            })
+            .catch(_ => {
+                handleNoSupplementaryData();
+            })
+    }
+
+    function loadSchemaMetadata(schemaName, schemaUrl) {
+        let survey_data_url = `/survey-data?schema_name=${schemaName}`
+        if (schemaUrl ){
+            survey_data_url += `&schema_url=${schemaUrl}`
         }
+        toggleSupplementaryData("hide");
+        getDataAsync(survey_data_url)
+            .then(schema_response => {
+                document.querySelector("#survey_metadata").innerHTML = "";
+                document.querySelector("#survey_metadata").innerHTML = "";
 
-        function loadSupplementaryDataInfo () {
-            const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
-            const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
-            if (selectedDataset) {
-                const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
+                if (schema_response.metadata.length > 0) {
+                    document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
 
-                document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
-                    key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
-                ).join('')
-            }
+                        const fieldName = metadataField["name"]
+                        const defaultValue = metadataField['default'];
+
+                        return `<div class="field-container">${getLabelFor(fieldName)}${
+                            (() => {
+                                if (metadataField['type'] === "boolean") {
+                                    return getInputField(fieldName, "checkbox");
+                                }
+                                else if (metadataField['type'] === "uuid") {
+                                    return (
+                                        `<span class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
+                                        `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
+                                        `</span>`
+                                    );
+                                }
+                                else if (fieldName === "survey_id" || fieldName === "period_id") {
+                                    return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
+                                }
+                                else if (fieldName === "sds_dataset_id") {
+                                    return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
+                                }
+                                else {
+                                    return getInputField(fieldName, "text", defaultValue)
+                                }
+                            })()
+                        }</div>`
+                    }).join("")
+                    updateSDSDropdown()
+                } else {
+                    document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                }
+
+                toggleSubmitFlushButtons("show");
+            })
+            .catch(_ => {
+                document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
+            })
+    }
+
+    function loadSupplementaryDataInfo () {
+        const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
+        const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
+        if (selectedDataset) {
+            const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
+
+            document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
+                key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
+            ).join('')
         }
+    }
 
-        function uuid(el_id) {
-            document.querySelector(`#${el_id}`).value = uuidv4();
+    function uuid(el_id) {
+        document.querySelector(`#${el_id}`).value = uuidv4();
+    }
+
+    function numericId() {
+        let result = '';
+        let chars = '0123456789';
+        for (let i = 16; i > 0; --i) {
+            result += chars[Math.round(Math.random() * (chars.length - 1))];
         }
+        document.querySelector(`#response_id`).value = result;
+    }
 
-        function numericId() {
-            let result = '';
-            let chars = '0123456789';
-            for (let i = 16; i > 0; --i) {
-                result += chars[Math.round(Math.random() * (chars.length - 1))];
-            }
-            document.querySelector(`#response_id`).value = result;
+    function setResponseExpiry(days_offset=7) {
+        let dt = new Date();
+        dt.setDate(dt.getDate()+days_offset)
+        document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
+    }
+
+    function validateForm() {
+        validateResponseExpiresAt();
+    }
+
+    function validateResponseExpiresAt() {
+        let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
+        if (isNaN(responseExpiresAt)) {
+            document.querySelector('#response_expires_at').remove()
         }
+    }
 
-        function setResponseExpiry(days_offset=7) {
-            let dt = new Date();
-            dt.setDate(dt.getDate()+days_offset)
-            document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
-        }
+    function resetDropdowns() {
+        document.getElementById('launch_pattern').selectedIndex = -1;
+        document.getElementById('schema_name').selectedIndex = -1;
+        document.getElementById('schema-url-survey-type').selectedIndex = -1;
+    }
 
-        function validateForm() {
-            validateResponseExpiresAt();
-        }
+    uuid('collection_exercise_sid');
+    uuid('case_id');
+    numericId();
+    setResponseExpiry();
 
-        function validateResponseExpiresAt() {
-            let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
-            if (isNaN(responseExpiresAt)) {
-                document.querySelector('#response_expires_at').remove()
-            }
-        }
-
-        function resetDropdowns() {
-            document.getElementById('launch_pattern').selectedIndex = -1;
-            document.getElementById('schema_name').selectedIndex = -1;
-            document.getElementById('schema-url-survey-type').selectedIndex = -1;
-        }
-
-        uuid('collection_exercise_sid');
-        uuid('case_id');
-        numericId();
-        setResponseExpiry();
-
-    </script>
+</script>
 
 {{ end }}

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -331,10 +331,8 @@
         }
 
         function handleNoSupplementaryData() {
-
             toggleSupplementaryData("hide");
             toggleSubmitFlushButtons("hide");
-
         }
 
         function updateSDSDropdown() {
@@ -352,7 +350,10 @@
                         displayLaunchButton(false)
                     }
                 })
-                .catch(_ => handleNoSupplementaryData())
+                .catch(_ => {
+                    handleNoSupplementaryData();
+                    toggleSubmitFlushButtons("hide");
+                })
         }
 
         function loadSchemaMetadata(schemaName, schemaUrl) {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -350,13 +350,11 @@
                         loadSupplementaryDataInfo();
                         displayLaunchButton(false);
                     } else if (document.querySelector("#sds_dataset_id")) {
-                        document.querySelector("#sds_dataset_id").innerHTML = "";
-                        toggleSubmitFlushButtons("hide");
+                        handleNoSupplementaryData();
                     }
                 })
                 .catch(_ => {
                     handleNoSupplementaryData();
-                    toggleSubmitFlushButtons("hide");
                 })
         }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -54,7 +54,7 @@
                     </span>
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <input type="submit" onClick="displayLaunchButton(true); return loadMetadataForSchemaUrl();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
                 </div>
 
@@ -63,18 +63,20 @@
                 <div id="survey_metadata_fields">
                 </div>
 
-                <h3 class="group-title--hidden">Survey Metadata</h3>
+                <h3>Survey Metadata</h3>
                 <div id="survey_metadata">
                     <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
                 </div>
 
-                <h3 class="supplementary-data--hidden">Supplementary Data</h3>
-                <div class="supplementary-data--hidden" id="supplementary_data">
+                <div class="supplementary-data supplementary-data--hidden">
+                    <h3>Supplementary Data</h3>
+                    <div id="supplementary_data">
+                    </div>
                 </div>
 
-                <h3 class="group-title--hidden">Required Data</h3>
+                <h3>Required Data</h3>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="case_id">Case ID</label>
                     <span class="field-container__span">
                         <input id="case_id" name="case_id" type="text" class="qa-case_id">
@@ -82,7 +84,7 @@
                     </span>
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="response_id">Response ID</label>
                     <span class="field-container__span">
                         <input id="response_id" name="response_id" type="text" class="qa-response_id">
@@ -90,7 +92,7 @@
                     </span>
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="collection_exercise_sid">Collection Exercise SID</label>
                     <span class="field-container__span">
                         <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
@@ -98,7 +100,7 @@
                     </span>
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="response_expires_at">Response Expiry Time</label>
                     <span class="field-container__span">
                         <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
@@ -107,13 +109,13 @@
                 </div>
 
 
-                <h3 class="group-title--hidden">Runner Data</h3>
-                <div class="field-container field-container--hidden">
+                <h3>Runner Data</h3>
+                <div class="field-container">
                     <label for="exp">Token Expiry (seconds)</label>
                     <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="language_code">Language</label>
                     <select id="language_code" name="language_code" class="qa-language-code">
                         <option value="en">English (en)</option>
@@ -124,7 +126,7 @@
                     </select>
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="roles">Roles</label>
                     <select id="roles" name="roles" multiple="multiple" class="qa-roles">
                         <option value="flusher">flusher</option>
@@ -132,19 +134,19 @@
                     </select>
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="account_service_url">Account Service URL</label>
                     <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
                 </div>
 
-                <div class="field-container field-container--hidden">
+                <div class="field-container">
                     <label for="account_service_log_out_url">Account Service Log Out URL</label>
                     <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
                 </div>
 
                 <div class="field-container">
-                    <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn button--hidden" id="submit-btn"/>
-                    <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn button--hidden" id="flush-btn"/>
+                    <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn"/>
+                    <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
                 </div>
 
             </form>
@@ -159,21 +161,30 @@
 
         function clearSurveyMetadataFields() {
             document.querySelector('#survey_metadata_fields').innerHTML = ""
-            hideSupplementaryData()
+            toggleSupplementaryData("hide");
         }
 
-        function showSupplementaryData () {
-            document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'block');
+        function toggleSupplementaryData(showHide) {
+            if (showHide == "hide") {
+                document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
+            } else if (showHide == "show") {
+                document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
+            }
         }
 
-        function hideSupplementaryData () {
-            document.querySelectorAll(".supplementary-data--hidden").forEach(element => element.style.display = 'none');
-        }
-
-        function showAllDivs() {
-            document.querySelectorAll("#survey_metadata, .field-container--hidden, .group-title--hidden").forEach(function (element) {
-                element.style.display = 'block';
-            });
+        function toggleSubmitFlushButtons(showHide, justSubmit = false) {
+            if (showHide == "hide") {
+                document.querySelector("#submit-btn").classList.add("btn--hidden");
+                if (!justSubmit) {
+                    document.querySelector("#flush-btn").classList.add("btn--hidden");
+                }
+            }
+            if (showHide == "show") {
+                document.querySelector("#submit-btn").classList.remove("btn--hidden");
+                if (!justSubmit) {
+                    document.querySelector("#flush-btn").classList.remove("btn--hidden");
+                }
+            }
         }
 
         function includeSurveyMetadataFields(schema_name, survey_type) {
@@ -181,12 +192,8 @@
             let eqIdValue = schema_name.split('_')[0]
             let formTypeValue = schema_name.split("_").slice(1).join("_")
 
-            document.querySelector('#survey_metadata_fields').style.display = "block";
-            document.querySelector('#supplementary_data').style.display = "block";
-
             if (launchPattern === "v1") {
-                document.querySelector('#survey_metadata_fields').innerHTML = `
-                    <h3>${survey_type} Survey Metadata</h3>
+                document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
                     <div class="field-container">
                         <label for="eq_id">eq_id</label>
                         <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
@@ -196,13 +203,15 @@
                         <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
                     </div>`
             } else {
-                document.querySelector('#survey_metadata_fields').innerHTML = `
-                    <h3>${survey_type} Survey Metadata</h3>
+                document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
                     <div class="field-container">
                         <label for="form_type">form_type</label>
                         <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
                     </div>`
             }
+
+            toggleSupplementaryData("show");
+            document.querySelector('#survey_metadata_fields').classList.remove("supplementary-data--hidden");
 
         }
 
@@ -210,12 +219,11 @@
             let schema_name = document.querySelector("#schema_name").value
 
             if (schema_name !== "Select Schema") {
-                document.querySelector(`#submit-btn`).style.display = 'inline-block';
-                document.querySelector("#flush-btn").style.display = 'inline-block';
+                toggleSubmitFlushButtons("show");
             }
 
             if (launchBySchemaUrl === true) {
-                document.querySelector(`#submit-btn`).style.display = 'inline-block';
+                toggleSubmitFlushButtons("show", true);
             }
         }
 
@@ -324,9 +332,9 @@
 
         function handleNoSupplementaryData() {
 
-            hideSupplementaryData()
-            document.querySelector(`#submit-btn`).style.display = 'none';
-            document.querySelector("#flush-btn").style.display = 'none';
+            document.querySelector("#sds_dataset_id").innerHTML = null;
+            toggleSupplementaryData("hide");
+            toggleSubmitFlushButtons("hide");
 
         }
 
@@ -337,7 +345,7 @@
                 .then(sds_metadata_response => {
                     if (sds_metadata_response?.length) {
                         supplementaryDataSets = sds_metadata_response
-                        showSupplementaryData()
+                        toggleSupplementaryData("show");
                         document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
                             `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
                             .join("");
@@ -355,7 +363,7 @@
             if (schemaUrl ){
                 survey_data_url += `&schema_url=${schemaUrl}`
             }
-            hideSupplementaryData()
+            toggleSupplementaryData("hide");
             getDataAsync(survey_data_url)
                 .then(schema_response => {
                     document.querySelector("#survey_metadata").innerHTML = "";
@@ -402,7 +410,7 @@
                         document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
                     }
 
-                    document.querySelector("#flush-btn").style.display = 'inline-block';
+                    toggleSubmitFlushButtons("show");
                 })
                 .catch(_ => {
                     document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
@@ -461,7 +469,6 @@
         uuid('case_id');
         numericId();
         setResponseExpiry();
-        showAllDivs();
 
     </script>
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -350,6 +350,7 @@
                         loadSupplementaryDataInfo();
                         displayLaunchButton(false);
                     } else if (document.querySelector("#sds_dataset_id")) {
+                        document.querySelector("#sds_dataset_id").innerHTML = "";
                         handleNoSupplementaryData();
                     }
                 })

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -373,13 +373,14 @@
                         document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
 
                             const fieldName = metadataField["name"]
-                            let defaultValue = metadataField['default'];
 
                             if (metadataField['type'] === "date") {
                                 const currentDate = new Date()
                                 // format as yyyy-MM-dd
                                 defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
                             }
+
+                            defaultValue = metadataField['default'];
 
                             return `<div class="field-container">${getLabelFor(fieldName)}${
                                 (() => {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -345,13 +345,6 @@
                         document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
 
                             const fieldName = metadataField["name"]
-
-                            if (metadataField['type'] === "date") {
-                                const currentDate = new Date()
-                                // format as yyyy-MM-dd
-                                defaultValue = currentDate.toLocaleDateString().split("/").reverse().join("-")
-                            }
-
                             defaultValue = metadataField['default'];
 
                             return `<div class="field-container">${getLabelFor(fieldName)}${

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -330,6 +330,31 @@
             return null
         }
 
+        function handleNoSupplementaryData() {
+
+            toggleSupplementaryData("hide");
+            toggleSubmitFlushButtons("hide");
+
+        }
+
+        function updateSDSDropdown() {
+            const surveyId = document.getElementById("survey_id")?.value;
+            const periodId = document.getElementById("period_id")?.value;
+            loadSDSDatasetMetadata(surveyId, periodId)
+                .then(sds_metadata_response => {
+                    if (sds_metadata_response?.length) {
+                        supplementaryDataSets = sds_metadata_response
+                        toggleSupplementaryData("show");
+                        document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
+                            `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
+                            .join("");
+                        loadSupplementaryDataInfo()
+                        displayLaunchButton(false)
+                    }
+                })
+                .catch(_ => handleNoSupplementaryData())
+        }
+
         function loadSchemaMetadata(schemaName, schemaUrl) {
             let survey_data_url = `/survey-data?schema_name=${schemaName}`
             if (schemaUrl ){
@@ -345,7 +370,7 @@
                         document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
 
                             const fieldName = metadataField["name"]
-                            defaultValue = metadataField['default'];
+                            const defaultValue = metadataField['default'];
 
                             return `<div class="field-container">${getLabelFor(fieldName)}${
                                 (() => {
@@ -360,7 +385,7 @@
                                         );
                                     }
                                     else if (fieldName === "survey_id" || fieldName === "period_id") {
-                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false);
+                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
                                     }
                                     else if (fieldName === "sds_dataset_id") {
                                         return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
@@ -371,6 +396,7 @@
                                 })()
                             }</div>`
                         }).join("")
+                        updateSDSDropdown()
                     } else {
                         document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
                     }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -380,7 +380,7 @@
                                     }
                                     else if (metadataField['type'] === "uuid") {
                                         return (
-                                            `<span  class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
+                                            `<span class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
                                             `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
                                             `</span>`
                                         );

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -330,34 +330,6 @@
             return null
         }
 
-        function handleNoSupplementaryData() {
-
-            document.querySelector("#sds_dataset_id").innerHTML = null;
-            toggleSupplementaryData("hide");
-            toggleSubmitFlushButtons("hide");
-
-        }
-
-        function updateSDSDropdown() {
-            const surveyId = document.getElementById("survey_id")?.value;
-            const periodId = document.getElementById("period_id")?.value;
-            loadSDSDatasetMetadata(surveyId, periodId)
-                .then(sds_metadata_response => {
-                    if (sds_metadata_response?.length) {
-                        supplementaryDataSets = sds_metadata_response
-                        toggleSupplementaryData("show");
-                        document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
-                            `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
-                            .join("");
-                        loadSupplementaryDataInfo()
-                        displayLaunchButton(false)
-                    } else {
-                        handleNoSupplementaryData()
-                    }
-                })
-                .catch(_ => handleNoSupplementaryData())
-        }
-
         function loadSchemaMetadata(schemaName, schemaUrl) {
             let survey_data_url = `/survey-data?schema_name=${schemaName}`
             if (schemaUrl ){
@@ -395,7 +367,7 @@
                                         );
                                     }
                                     else if (fieldName === "survey_id" || fieldName === "period_id") {
-                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
+                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false);
                                     }
                                     else if (fieldName === "sds_dataset_id") {
                                         return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
@@ -406,7 +378,6 @@
                                 })()
                             }</div>`
                         }).join("")
-                        updateSDSDropdown()
                     } else {
                         document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
                     }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -218,7 +218,6 @@
         }
 
         function displayLaunchButton(launchBySchemaUrl) {
-            let version = document.querySelector("#launch_pattern").value
             let schema_name = document.querySelector("#schema_name").value
 
             if (schema_name !== "Select Schema") {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -10,7 +10,7 @@
                 <strong><u>Launch Pattern</u></strong>
                 <div class="field-container">
                     <label for="launch_pattern">Version</label>
-                    <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName();">
+                    <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
                         <option value="v1">v1</option>
                         <option value="v2" selected="selected">v2</option>
                     </select>


### PR DESCRIPTION
### What is the context of this PR?
This is to change the version dropdown to default to v2. Just to make things a bit easier for the user.

- Also fixes console error around a null field trying to be set to null
- Tidies up some formatting
- Refactors the show hide css js for some elements to make more sense
- Fixes a bug with the default value for `ref_p_start_date` and `ref_p_end_date` not being used

### How to review
- Check that v2 is selected now when launcher is loaded
- Check that schemas load as expected when selected from dropdown and using a url
