### PR TITLE
Add support for launching CIR Surveys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ vendor/
 
 # binaries
 eq-questionnaire-launcher
+
+# Dev config
+.vscode/

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -365,6 +365,8 @@ func getSchemaClaims(LauncherSchema surveys.LauncherSchema) map[string]interface
 	schemaClaims := make(map[string]interface{})
 	if LauncherSchema.URL != "" {
 		schemaClaims["schema_url"] = LauncherSchema.URL
+	} else if LauncherSchema.CIRInstrumentID != "" {
+		schemaClaims["cir_instrument_id"] = LauncherSchema.CIRInstrumentID
 	}
 
 	return schemaClaims
@@ -580,8 +582,9 @@ func GenerateTokenFromPost(postValues url.Values, launchVersion2 bool) (string, 
 
 	schemaName := TransformSchemaParamsToName(postValues)
 	schemaUrl := postValues.Get("schema_url")
+	cirInstrumentId := postValues.Get("cir_instrument_id")
 
-	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl)
+	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl, cirInstrumentId)
 
 	schema, error := getSchema(launcherSchema)
 	if error != "" {
@@ -678,6 +681,11 @@ func getSchema(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, stri
 
 	if launcherSchema.URL != "" {
 		url = launcherSchema.URL
+	} else if launcherSchema.CIRInstrumentID != "" {
+		hostURL := settings.Get("CIR_API_BASE_URL")
+
+		log.Println("Collection Instrument ID: ", launcherSchema.CIRInstrumentID)
+		url = fmt.Sprintf("%s/v2/retrieve_collection_instrument?guid=%s", hostURL, launcherSchema.CIRInstrumentID)
 	} else {
 		hostURL := settings.Get("SURVEY_RUNNER_SCHEMA_URL")
 

--- a/launch.go
+++ b/launch.go
@@ -87,8 +87,9 @@ func postLaunchHandler(w http.ResponseWriter, r *http.Request) {
 func getSurveyDataHandler(w http.ResponseWriter, r *http.Request) {
 	schemaName := r.URL.Query().Get("schema_name")
 	schemaUrl := r.URL.Query().Get("schema_url")
+	cirInstrumentId := r.URL.Query().Get("cir_instrument_id")
 
-	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl)
+	launcherSchema := surveys.GetLauncherSchema(schemaName, schemaUrl, cirInstrumentId)
 
 	surveyData, err := authentication.GetSurveyData(launcherSchema)
 
@@ -100,8 +101,6 @@ func getSurveyDataHandler(w http.ResponseWriter, r *http.Request) {
 	surveyDataJSON, _ := json.Marshal(surveyData)
 
 	w.Write([]byte(surveyDataJSON))
-
-	return
 }
 
 func getSupplementaryDataHandler(w http.ResponseWriter, r *http.Request) {
@@ -116,6 +115,17 @@ func getSupplementaryDataHandler(w http.ResponseWriter, r *http.Request) {
 	datasetJSON, _ := json.Marshal(datasets)
 
 	w.Write([]byte(datasetJSON))
+}
+
+func getCIRHandler(w http.ResponseWriter, r *http.Request) {
+	ciMetadata, err := surveys.GetAvailableSchemasFromCIR()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("GetAvailableSchemasFromCIR err: %v", err), 500)
+		return
+	}
+	ciMetadataJSON, _ := json.Marshal(ciMetadata)
+
+	w.Write([]byte(ciMetadataJSON))
 }
 
 func getAccountServiceURL(r *http.Request) string {
@@ -222,6 +232,7 @@ func main() {
 	r.HandleFunc("/", postLaunchHandler).Methods("POST")
 	r.HandleFunc("/survey-data", getSurveyDataHandler).Methods("GET")
 	r.HandleFunc("/supplementary-data", getSupplementaryDataHandler).Methods("GET")
+	r.HandleFunc("/collection-instrument-registry", getCIRHandler).Methods("GET")
 
 	//Author Launcher with passed parameters in Url
 	r.HandleFunc("/quick-launch", quickLauncherHandler).Methods("GET")

--- a/launch.go
+++ b/launch.go
@@ -58,6 +58,7 @@ func serveTemplate(templateName string, data interface{}, w http.ResponseWriter,
 
 type page struct {
 	Schemas                 map[string][]surveys.LauncherSchema
+	CirSchemas              []surveys.CIMetadata
 	AccountServiceURL       string
 	AccountServiceLogOutURL string
 }
@@ -69,6 +70,7 @@ func getStatusPage(w http.ResponseWriter, r *http.Request) {
 func getLaunchHandler(w http.ResponseWriter, r *http.Request) {
 	p := page{
 		Schemas:                 surveys.GetAvailableSchemas(),
+		CirSchemas:              surveys.GetAvailableSchemasFromCIR(),
 		AccountServiceURL:       getAccountServiceURL(r),
 		AccountServiceLogOutURL: getAccountServiceURL(r),
 	}
@@ -115,17 +117,6 @@ func getSupplementaryDataHandler(w http.ResponseWriter, r *http.Request) {
 	datasetJSON, _ := json.Marshal(datasets)
 
 	w.Write([]byte(datasetJSON))
-}
-
-func getCIRHandler(w http.ResponseWriter, r *http.Request) {
-	ciMetadata, err := surveys.GetAvailableSchemasFromCIR()
-	if err != nil {
-		http.Error(w, fmt.Sprintf("GetAvailableSchemasFromCIR err: %v", err), 500)
-		return
-	}
-	ciMetadataJSON, _ := json.Marshal(ciMetadata)
-
-	w.Write([]byte(ciMetadataJSON))
 }
 
 func getAccountServiceURL(r *http.Request) string {
@@ -232,7 +223,6 @@ func main() {
 	r.HandleFunc("/", postLaunchHandler).Methods("POST")
 	r.HandleFunc("/survey-data", getSurveyDataHandler).Methods("GET")
 	r.HandleFunc("/supplementary-data", getSupplementaryDataHandler).Methods("GET")
-	r.HandleFunc("/collection-instrument-registry", getCIRHandler).Methods("GET")
 
 	//Author Launcher with passed parameters in Url
 	r.HandleFunc("/quick-launch", quickLauncherHandler).Methods("GET")

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -21,6 +21,7 @@ func init() {
 	setSetting("SCHEMA_VALIDATOR_URL", "")
 	setSetting("SURVEY_REGISTER_URL", "")
 	setSetting("SDS_API_BASE_URL", "http://localhost:5003")
+	setSetting("CIR_API_BASE_URL", "http://localhost:5004")
 	setSetting("JWT_ENCRYPTION_KEY_PATH", "jwt-test-keys/sdc-user-authentication-encryption-sr-public-key.pem")
 	setSetting("JWT_SIGNING_KEY_PATH", "jwt-test-keys/sdc-user-authentication-signing-launcher-private-key.pem")
 	setSetting("OIDC_TOKEN_VALIDITY_IN_SECONDS", "3600")

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,7 +11,7 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
     position: relative;
 }
 
-.btn--hidden, .supplementary-data--hidden {
+.btn--hidden, .supplementary-data--hidden, .cir-metadata--hidden {
     display:none;
 }
 

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -143,7 +143,7 @@ func getAvailableSchemasFromRegister() []LauncherSchema {
 	return schemaList
 }
 
-func GetAvailableSchemasFromCIR() ([]CIMetadata, error) {
+func GetAvailableSchemasFromCIR() []CIMetadata {
 
 	ciMetadataList := []CIMetadata{}
 
@@ -155,20 +155,25 @@ func GetAvailableSchemasFromCIR() ([]CIMetadata, error) {
 
 	resp, err := clients.GetHTTPClient().Get(url)
 	if err != nil || resp.StatusCode != 200 {
-		return ciMetadataList, errors.New("unable to fetch Collection Instruments")
+		log.Print(err)
+		return ciMetadataList
 	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return ciMetadataList, errors.New("unable to read response body of Collection Instruments")
+		log.Print(err)
+		return ciMetadataList
 	}
 
 	if err := json.Unmarshal(responseBody, &ciMetadataList); err != nil {
 		log.Print(err)
-		return []CIMetadata{}, fmt.Errorf("%v", err)
+		return ciMetadataList
 	}
-	return ciMetadataList, nil
+	// Easier to navigate schemas in alphabetical order
+	sort.Slice(ciMetadataList, func(i, j int) bool { return ciMetadataList[i].FormType < ciMetadataList[j].FormType })
+
+	return ciMetadataList
 }
 
 func getAvailableSchemasFromRunner() []LauncherSchema {

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -19,9 +19,25 @@ import (
 
 // LauncherSchema is a representation of a schema in the Launcher
 type LauncherSchema struct {
-	Name       string
-	SurveyType string
-	URL        string
+	Name            string
+	SurveyType      string
+	URL             string
+	CIRInstrumentID string
+}
+
+type CIMetadata struct {
+	CIVersion     int    `json:"ci_version"`
+	DataVersion   string `json:"data_version"`
+	FormType      string `json:"form_type"`
+	ID            string `json:"id"`
+	Language      string `json:"language"`
+	PublishedAt   string `json:"published_at"`
+	SchemaVersion string `json:"schema_version"`
+	Status        string `json:"status"`
+	SurveyID      string `json:"survey_id"`
+	Title         string `json:"title"`
+	Description   string `json:"description"`
+	SDSSchema     string `json:"sds_schema"`
 }
 
 type DatasetMetadata struct {
@@ -127,6 +143,34 @@ func getAvailableSchemasFromRegister() []LauncherSchema {
 	return schemaList
 }
 
+func GetAvailableSchemasFromCIR() ([]CIMetadata, error) {
+
+	ciMetadataList := []CIMetadata{}
+
+	hostURL := settings.Get("CIR_API_BASE_URL")
+
+	log.Printf("CIR API Base URL: %s", hostURL)
+
+	url := fmt.Sprintf("%s/v2/ci_metadata", hostURL)
+
+	resp, err := clients.GetHTTPClient().Get(url)
+	if err != nil || resp.StatusCode != 200 {
+		return ciMetadataList, errors.New("unable to fetch Collection Instruments")
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return ciMetadataList, errors.New("unable to read response body of Collection Instruments")
+	}
+
+	if err := json.Unmarshal(responseBody, &ciMetadataList); err != nil {
+		log.Print(err)
+		return []CIMetadata{}, fmt.Errorf("%v", err)
+	}
+	return ciMetadataList, nil
+}
+
 func getAvailableSchemasFromRunner() []LauncherSchema {
 
 	schemaList := []LauncherSchema{}
@@ -226,7 +270,7 @@ func GetSupplementaryDataSets(surveyId string, periodId string) ([]DatasetMetada
 }
 
 // Return a LauncherSchema instance by loading schema from name or URL
-func GetLauncherSchema(schemaName string, schemaUrl string) LauncherSchema {
+func GetLauncherSchema(schemaName string, schemaUrl string, cirInstrumentId string) LauncherSchema {
 	var launcherSchema LauncherSchema
 
 	if schemaUrl != "" {
@@ -235,11 +279,16 @@ func GetLauncherSchema(schemaName string, schemaUrl string) LauncherSchema {
 			URL:  schemaUrl,
 			Name: schemaName,
 		}
+	} else if cirInstrumentId != "" {
+		log.Println("Searching for schema by CIR Instrument ID: " + cirInstrumentId)
+		launcherSchema = LauncherSchema{
+			CIRInstrumentID: cirInstrumentId,
+		}
 	} else if schemaName != "" {
 		log.Println("Searching for schema by name: " + schemaName)
 		launcherSchema = FindSurveyByName(schemaName)
 	} else {
-		panic("Either `schema_name` or `schema_url` must be provided.")
+		panic("Either `schema_name` or `schema_url` or `cir_instrument_id` must be provided.")
 	}
 
 	return launcherSchema

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -59,6 +59,9 @@
                     <label for="cir-schemas">CIR Schema</label>
                     <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
                         <option selected disabled>Select Schema</option>
+                        {{ range $cirSchema := .CirSchemas }}
+                        <option value="{{ $cirSchema.ID }}" data-form-type="{{ $cirSchema.FormType }}" data-version="{{ $cirSchema.CIVersion }}" data-language="{{ $cirSchema.Language }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>      
+                        {{ end }}
                     </select>
                 </span>
             </div>
@@ -173,14 +176,12 @@
     // uuidv4: from https://github.com/kelektiv/node-uuid
     !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
-    // store results of external api calls so they only need to be made once
+    // store fetch so it only needs to be re-done if the survey changes
     let supplementaryDataSets = null;
-    let cirSchemas = null;
 
     function clearSurveyMetadataFields() {
         document.querySelector('#survey_metadata_fields').innerHTML = ""
         toggleSupplementaryData("hide");
-        toggleCIRMetadata("hide")
     }
 
     function setSurveyType(event) {
@@ -208,10 +209,9 @@
             if (schemaName.selectedIndex) {
                 clearSurveyMetadataFields();
                 toggleSubmitFlushButtons("hide");
-            }
-                
-            schemaName.selectedIndex = 0
-            localStorage.removeItem("schema_name")
+                schemaName.selectedIndex = 0
+                localStorage.removeItem("schema_name")                
+            }                            
 
             if (launchType === "cir") {
                 schemaUrl.value = ""  
@@ -219,7 +219,7 @@
             }
             else if (launchType === "url") {
                 cirSchemas.selectedIndex = 0
-                localStorage.removeItem("cir_schema")
+                localStorage.removeItem("cir_schema")                
             }
         }
         if (launchType === "name") {
@@ -229,6 +229,7 @@
             localStorage.removeItem("schema_url")
             localStorage.removeItem("cir_schema")
             localStorage.removeItem("survey_type")
+            document.querySelector("#language_code").disabled = false;            
         }
     }
 
@@ -306,8 +307,8 @@
         let schemaUrl = document.querySelector("#schema-url").value
         let surveyType = document.querySelector("#remote-schema-survey-type")
 
-        let cirSchema = document.querySelector("#cir-schemas")
-        let cirInstrumentId = cirSchema.selectedIndex ? cirSchema.value : null
+        let cirSchemaDropdown = document.querySelector("#cir-schemas")        
+        let cirInstrumentId = cirSchemaDropdown.selectedIndex ? cirSchemaDropdown.value : null
         
         let schemaName = null
 
@@ -321,20 +322,25 @@
             return false
         }
 
-        if (!schemaUrl && !cirSchema.selectedIndex) {
+        if (!schemaUrl && !cirInstrumentId) {
             alert("Enter a Schema URL or select a CIR Schema.")
             return false
         }
 
         if (schemaUrl){
             schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+            document.querySelector("#language_code").disabled = false;
         }
         else {
-            ciMetadata = cirSchemas.find(schema => schema.id === cirInstrumentId)
-            schemaName = ciMetadata.form_type
-            showCIRMetdata(ciMetadata);
-            // cir schemas already include language
-            populateDropDownWithValue("#language_code", ciMetadata.language)
+            let cirSchema = cirSchemaDropdown.options[cirSchemaDropdown.selectedIndex]
+            schemaName = cirSchema.getAttribute("data-form-type")
+            let ciVersion = cirSchema.getAttribute("data-version")
+            let language = cirSchema.getAttribute("data-language")
+
+            showCIRMetdata(cirInstrumentId, ciVersion);
+        
+            // cir schemas are for a specific language, so populate and disable choosing it
+            populateDropDownWithValue("#language_code", language)
             document.querySelector("#language_code").disabled = true;
         }
         
@@ -392,12 +398,12 @@
         toggleSubmitFlushButtons("hide");
     }
 
-    function showCIRMetdata(metadata) {
+    function showCIRMetdata(cirInstrumentId, ciVersion) {
         toggleCIRMetadata("show");
-        const ciMetadataKeys = ["id", "ci_version"];
-        document.querySelector("#cir_metadata").innerHTML = ciMetadataKeys.map(
-            key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", metadata[key], true)}</div>`
-        ).join('')
+        document.querySelector("#cir_metadata").innerHTML = `
+            <div class="field-container">${getLabelFor("id")}${getInputField("id", "text", cirInstrumentId, true)}</div>
+            <div class="field-container">${getLabelFor("ci_version")}${getInputField("ci_version", "text", ciVersion, true)}</div>
+        `
     }
 
     function updateSDSDropdown() {
@@ -420,20 +426,6 @@
             })
             .catch(_ => {
                 handleNoSupplementaryData();
-            })
-    }
-
-    async function loadCIRSchemas() {
-        let cir_url = `/collection-instrument-registry`
-        await getDataAsync(cir_url)
-            .then(cir_response => {
-                cirSchemas = cir_response.sort((a, b) => a.form_type < b.form_type ? -1 : 1)
-                document.querySelector("#cir-schemas").innerHTML += cirSchemas.map(schema =>
-                    `<option value="${schema.id}">${schema.form_type} (${schema.language})</option>`)
-                    .join("");
-            })
-            .catch(_ => {
-                document.querySelector("#cir-schemas").disabled = true
             })
     }
 
@@ -576,13 +568,12 @@
         }
     }
 
-    async function onLoad() {
+    function onLoad() {
         uuid('collection_exercise_sid');
         uuid('case_id');
         numericId();
         setResponseExpiry();
         retrieveResponseId();
-        await loadCIRSchemas();
 
         if (schemaName = localStorage.getItem("schema_name")){
             populateDropDownWithValue("#schema_name", schemaName)

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -171,7 +171,7 @@
             <div class="field-container">
                 <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn" onclick="saveResponseId()"/>
                 <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
-                <input type="button" value="Clear Local Storage" class="qa-btn-submit-dev btn btn--hidden" id="local-storage-btn" onclick="clearLocalStorage()"/>
+                <input type="button" value="Clear Local Storage" class="qa-btn-submit-dev btn" id="local-storage-btn" onclick="clearLocalStorage()"/>
             </div>
 
         </form>

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -186,7 +186,7 @@
 
     function clearSurveyMetadataFields() {
         document.querySelector('#survey_metadata_fields').innerHTML = ""
-        toggleSupplementaryData("hide");
+        showSupplementaryData(false);
     }
 
     function setSurveyType(event) {
@@ -213,7 +213,7 @@
         if(launchType === "cir" || launchType === "remote" || launchType === "url"){
             if (schemaName.selectedIndex) {
                 clearSurveyMetadataFields();
-                toggleSubmitFlushButtons("hide");
+                showSubmitFlushButtons(false);
                 schemaName.selectedIndex = 0
                 localStorage.removeItem("schema_name")                
             }                            
@@ -238,33 +238,34 @@
         }
     }
 
-    function toggleSupplementaryData(showHide) {
-        if (showHide == "hide") {
-            document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
-        } else if (showHide == "show") {
+    function showSupplementaryData(show) {
+        if (show) {
             document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
         }
+        else{
+            document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
+        }
     }
 
-    function toggleCIRMetadata(showHide) {
-        if (showHide == "hide") {
-            document.querySelector(".cir-metadata").classList.add("cir-metadata--hidden");
-        } else if (showHide == "show") {
+    function showCIRMetadata(show) {
+        if (show) {
             document.querySelector(".cir-metadata").classList.remove("cir-metadata--hidden");
         }
+        else {
+            document.querySelector(".cir-metadata").classList.add("cir-metadata--hidden");
+        }
     }
 
-    function toggleSubmitFlushButtons(showHide, justSubmit = false) {
-        if (showHide == "hide") {
-            document.querySelector("#submit-btn").classList.add("btn--hidden");
-            if (!justSubmit) {
-                document.querySelector("#flush-btn").classList.add("btn--hidden");
-            }
-        }
-        if (showHide == "show") {
+    function showSubmitFlushButtons(show, justSubmit = false) {
+        if (show) {
             document.querySelector("#submit-btn").classList.remove("btn--hidden");
             if (!justSubmit) {
                 document.querySelector("#flush-btn").classList.remove("btn--hidden");
+            }
+        } else {
+            document.querySelector("#submit-btn").classList.add("btn--hidden");
+            if (!justSubmit) {
+                document.querySelector("#flush-btn").classList.add("btn--hidden");
             }
         }
     }
@@ -292,7 +293,7 @@
                 </div>`
         }
 
-        toggleSupplementaryData("show");
+        showSupplementaryData(true);
         document.querySelector('#survey_metadata_fields').classList.remove("supplementary-data--hidden");
 
     }
@@ -350,7 +351,7 @@
         
         loadSurveyMetadata(schemaName, surveyType.value)
         loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId)
-        toggleSubmitFlushButtons("show");
+        showSubmitFlushButtons(true);
     }
 
     function loadSurveyMetadata(schema_name, survey_type) {
@@ -398,12 +399,12 @@
     }
 
     function handleNoSupplementaryData() {
-        toggleSupplementaryData("hide");
-        toggleSubmitFlushButtons("hide");
+        showSupplementaryData(false);
+        showSubmitFlushButtons(false);
     }
 
     function showCIRMetdata(cirInstrumentId, cirSchema) {
-        toggleCIRMetadata("show");
+        showCIRMetadata(true);
         let ciMetadata = {
             "id": cirInstrumentId,
             "ci_version": cirSchema.getAttribute("data-version"),            
@@ -422,8 +423,8 @@
             .then(sds_metadata_response => {
                 if (sds_metadata_response?.length) {
                     supplementaryDataSets = sds_metadata_response
-                    toggleSupplementaryData("show");
-                    toggleSubmitFlushButtons("show");
+                    showSupplementaryData(true);
+                    showSubmitFlushButtons(true);
                     document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
                         `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
                         .join("");
@@ -445,13 +446,13 @@
             survey_data_url += `&cir_instrument_id=${cirInstrumentId}`
         }
         else {
-            toggleCIRMetadata("hide");
+            showCIRMetadata(false);
             if (schemaName)
                 survey_data_url += `&schema_name=${schemaName}`
             if (schemaUrl)
                 survey_data_url += `&schema_url=${schemaUrl}`
         }
-        toggleSupplementaryData("hide");
+        showSupplementaryData(false);
         getDataAsync(survey_data_url)
             .then(schema_response => {
                 document.querySelector("#survey_metadata").innerHTML = "";
@@ -491,7 +492,7 @@
                 } else {
                     document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
                 }
-                toggleSubmitFlushButtons("show");
+                showSubmitFlushButtons(true);
             })
             .catch(_ => {
                 document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -60,7 +60,12 @@
                     <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
                         <option selected disabled>Select Schema</option>
                         {{ range $cirSchema := .CirSchemas }}
-                        <option value="{{ $cirSchema.ID }}" data-form-type="{{ $cirSchema.FormType }}" data-version="{{ $cirSchema.CIVersion }}" data-language="{{ $cirSchema.Language }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>      
+                        <option value="{{ $cirSchema.ID }}" 
+                            data-form-type="{{ $cirSchema.FormType }}" 
+                            data-version="{{ $cirSchema.CIVersion }}" 
+                            data-language="{{ $cirSchema.Language }}"
+                            data-title="{{ $cirSchema.Title }}"
+                            data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>      
                         {{ end }}
                     </select>
                 </span>
@@ -334,10 +339,9 @@
         else {
             let cirSchema = cirSchemaDropdown.options[cirSchemaDropdown.selectedIndex]
             schemaName = cirSchema.getAttribute("data-form-type")
-            let ciVersion = cirSchema.getAttribute("data-version")
             let language = cirSchema.getAttribute("data-language")
 
-            showCIRMetdata(cirInstrumentId, ciVersion);
+            showCIRMetdata(cirInstrumentId, cirSchema);
         
             // cir schemas are for a specific language, so populate and disable choosing it
             populateDropDownWithValue("#language_code", language)
@@ -398,12 +402,17 @@
         toggleSubmitFlushButtons("hide");
     }
 
-    function showCIRMetdata(cirInstrumentId, ciVersion) {
+    function showCIRMetdata(cirInstrumentId, cirSchema) {
         toggleCIRMetadata("show");
-        document.querySelector("#cir_metadata").innerHTML = `
-            <div class="field-container">${getLabelFor("id")}${getInputField("id", "text", cirInstrumentId, true)}</div>
-            <div class="field-container">${getLabelFor("ci_version")}${getInputField("ci_version", "text", ciVersion, true)}</div>
-        `
+        let ciMetadata = {
+            "id": cirInstrumentId,
+            "ci_version": cirSchema.getAttribute("data-version"),            
+            "title": cirSchema.getAttribute("data-title"),
+            "description": cirSchema.getAttribute("data-description"),
+        }
+        document.querySelector("#cir_metadata").innerHTML = Object.keys(ciMetadata).map(
+            key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", ciMetadata[key], true)}</div>`
+            ).join('')
     }
 
     function updateSDSDropdown() {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -2,7 +2,7 @@
 
 {{ define "body" }}
 
-<body onbeforeunload="resetDropdowns();" onload="retrieveSchemaName();retrieveResponseId();">
+<body onload="onLoad()">
     <h1>Launch a survey</h1>
     <div>
         <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
@@ -10,7 +10,7 @@
             <strong><u>Launch Pattern</u></strong>
             <div class="field-container">
                 <label for="launch_pattern">Version</label>
-                <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
+                <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); ">
                     <option value="v1">v1</option>
                     <option value="v2" selected="selected">v2</option>
                 </select>
@@ -19,7 +19,7 @@
             <strong><u>Launch by Schema Name</u></strong>
             <div class="field-container">
                 <label for="schema_name">Schemas</label>
-                <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); displayLaunchButton(false);">
+                <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); setLaunchType('name')">
                     <option selected disabled>Select Schema</option>
 
                     {{ range $surveyType, $schemasList := .Schemas }}
@@ -34,11 +34,11 @@
 
             <p>----------</p>
 
-            <strong><u>Launch by Schema URL</u></strong>
+            <strong><u>Launch Remote Schemas</u></strong>
             <div class="field-container">
                 <span class="field-container__span">
-                    <label for="schema-url-survey-type">Survey Type</label>
-                    <select name="survey-types" id="schema-url-survey-type">
+                    <label for="remote-schema-survey-type">Survey Type</label>
+                    <select name="survey-types" id="remote-schema-survey-type" onchange="setSurveyType(this)">
                         <option selected disabled>Select Survey Type</option>
                         {{ range $surveyType, $schemasList := .Schemas }}
                         <option value="{{ $surveyType }}">{{ $surveyType }}</option>
@@ -50,17 +50,32 @@
             <div class="field-container">
                 <span class="field-container__span">
                     <label for="schema-url">Schema URL</label>
-                    <input id="schema-url" name="schema_url" type="text" class="qa-schema_url">
+                    <input id="schema-url" name="schema_url" type="text" class="qa-schema_url" onchange="setSchemaUrl(this)">
                 </span>
             </div>
 
             <div class="field-container">
-                <input type="submit" onClick="displayLaunchButton(true); return loadMetadataForSchemaUrl();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
+                <span class="field-container__span">
+                    <label for="cir-schemas">CIR Schema</label>
+                    <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
+                        <option selected disabled>Select Schema</option>
+                    </select>
+                </span>
+            </div>
+
+            <div class="field-container">
+                <input type="button" onClick="loadMetadataForRemoteSchema();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
             </div>
 
             <p>----------</p>
 
             <div id="survey_metadata_fields">
+            </div>
+
+            <div class="cir-metadata cir-metadata--hidden">
+                <h3>CIR Metadata</h3>
+                <div id="cir_metadata">
+                </div>
             </div>
 
             <h3>Survey Metadata</h3>
@@ -158,12 +173,63 @@
     // uuidv4: from https://github.com/kelektiv/node-uuid
     !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
 
-    // store fetch so it only needs to be re-done if the survey changes
+    // store results of external api calls so they only need to be made once
     let supplementaryDataSets = null;
+    let cirSchemas = null;
 
     function clearSurveyMetadataFields() {
         document.querySelector('#survey_metadata_fields').innerHTML = ""
         toggleSupplementaryData("hide");
+        toggleCIRMetadata("hide")
+    }
+
+    function setSurveyType(event) {
+        localStorage.setItem("survey_type", event.value)
+        setLaunchType("remote");
+    }
+
+    function setCirSchema(event) {
+        localStorage.setItem("cir_schema", event.value)
+        setLaunchType("cir");
+    }
+
+    function setSchemaUrl(event) {
+        localStorage.setItem("schema_url", event.value)
+        setLaunchType("url");
+    }
+
+    function setLaunchType(launchType) {
+        const schemaName = document.querySelector("#schema_name")
+        const schemaUrl = document.querySelector("#schema-url")
+        const cirSchemas = document.querySelector("#cir-schemas")
+        const remoteSchemaSurveyType = document.querySelector("#remote-schema-survey-type")
+
+        if(launchType === "cir" || launchType === "remote" || launchType === "url"){
+            if (schemaName.selectedIndex) {
+                clearSurveyMetadataFields();
+                toggleSubmitFlushButtons("hide");
+            }
+                
+            schemaName.selectedIndex = 0
+            localStorage.removeItem("schema_name")
+
+            if (launchType === "cir") {
+                schemaUrl.value = ""  
+                localStorage.removeItem("schema_url")              
+            }
+            else if (launchType === "url") {
+                cirSchemas.selectedIndex = 0
+                localStorage.removeItem("cir_schema")
+            }
+        }
+        if (launchType === "name") {
+            schemaUrl.value = ""
+            cirSchemas.selectedIndex = 0
+            remoteSchemaSurveyType.selectedIndex = 0
+            localStorage.removeItem("schema_url")
+            localStorage.removeItem("cir_schema")
+            localStorage.removeItem("survey_type")
+        }
     }
 
     function toggleSupplementaryData(showHide) {
@@ -171,6 +237,14 @@
             document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
         } else if (showHide == "show") {
             document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
+        }
+    }
+
+    function toggleCIRMetadata(showHide) {
+        if (showHide == "hide") {
+            document.querySelector(".cir-metadata").classList.add("cir-metadata--hidden");
+        } else if (showHide == "show") {
+            document.querySelector(".cir-metadata").classList.remove("cir-metadata--hidden");
         }
     }
 
@@ -217,75 +291,56 @@
 
     }
 
-    function displayLaunchButton(launchBySchemaUrl) {
-        let schema_name = document.querySelector("#schema_name").value
-
-        if (schema_name !== "Select Schema") {
-            toggleSubmitFlushButtons("show");
-        }
-
-        if (launchBySchemaUrl === true) {
-            toggleSubmitFlushButtons("show", true);
-        }
-    }
-
-    function clearAndDisableSchemaUrlSelection() {
-        document.querySelector("#schema-url-btn").disabled = true;
-
-        let schemaUrlElement = document.querySelector("#schema-url")
-        let surveyTypeElement = document.querySelector("#schema-url-survey-type")
-
-        surveyTypeElement.selectedIndex = 0
-        schemaUrlElement.value = ""
-        surveyTypeElement.disabled = true
-        schemaUrlElement.disabled = true
-    }
-
-    function clearAndDisableSchemaNameSelection() {
-        let schemaNameElement = document.querySelector("#schema_name")
-
-        schemaNameElement.selectedIndex = 0
-        schemaNameElement.disabled = true
-    }
-
     function loadMetadataForSchemaName() {
         let schemaName = document.querySelector("#schema_name").value;
         localStorage.setItem("schema_name", schemaName);
 
         if (schemaName !== "Select Schema") {
-            clearAndDisableSchemaUrlSelection();
-
             const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType;
-
             loadSurveyMetadata(schemaName, surveyType);
             loadSchemaMetadata(schemaName, null);
         }
     }
 
-    function loadMetadataForSchemaUrl() {
+    function loadMetadataForRemoteSchema() {
         let schemaUrl = document.querySelector("#schema-url").value
-        if (!schemaUrl || !schemaUrl.endsWith(".json")) {
-            alert("Schema URL not provided or is not valid.\n" +
-                "URL must end with '.json'")
+        let surveyType = document.querySelector("#remote-schema-survey-type")
+
+        let cirSchema = document.querySelector("#cir-schemas")
+        let cirInstrumentId = cirSchema.selectedIndex ? cirSchema.value : null
+        
+        let schemaName = null
+
+        if (schemaUrl && !schemaUrl.endsWith(".json")) {
+            alert("Schema URL is not valid URL must end with '.json'")
             return false
         }
 
-        let surveyType = document.querySelector("#schema-url-survey-type").value
-        if (surveyType.toLowerCase() === "select survey type") {
+        if (!surveyType.selectedIndex) {
             alert("Select a Survey Type.")
             return false
         }
 
-        clearAndDisableSchemaNameSelection()
+        if (!schemaUrl && !cirSchema.selectedIndex) {
+            alert("Enter a Schema URL or select a CIR Schema.")
+            return false
+        }
 
-        let schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
-
-        loadSurveyMetadata(schemaName, surveyType)
-        loadSchemaMetadata(schemaName, schemaUrl)
-
-        displayLaunchButton(false)
-
-        return false
+        if (schemaUrl){
+            schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+        }
+        else {
+            ciMetadata = cirSchemas.find(schema => schema.id === cirInstrumentId)
+            schemaName = ciMetadata.form_type
+            showCIRMetdata(ciMetadata);
+            // cir schemas already include language
+            populateDropDownWithValue("#language_code", ciMetadata.language)
+            document.querySelector("#language_code").disabled = true;
+        }
+        
+        loadSurveyMetadata(schemaName, surveyType.value)
+        loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId)
+        toggleSubmitFlushButtons("show");
     }
 
     function loadSurveyMetadata(schema_name, survey_type) {
@@ -337,6 +392,14 @@
         toggleSubmitFlushButtons("hide");
     }
 
+    function showCIRMetdata(metadata) {
+        toggleCIRMetadata("show");
+        const ciMetadataKeys = ["id", "ci_version"];
+        document.querySelector("#cir_metadata").innerHTML = ciMetadataKeys.map(
+            key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", metadata[key], true)}</div>`
+        ).join('')
+    }
+
     function updateSDSDropdown() {
         const surveyId = document.getElementById("survey_id")?.value;
         const periodId = document.getElementById("period_id")?.value;
@@ -350,7 +413,6 @@
                         `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
                         .join("");
                     loadSupplementaryDataInfo();
-                    displayLaunchButton(false);
                 } else if (document.querySelector("#sds_dataset_id")) {
                     document.querySelector("#sds_dataset_id").innerHTML = "";
                     handleNoSupplementaryData();
@@ -361,10 +423,32 @@
             })
     }
 
-    function loadSchemaMetadata(schemaName, schemaUrl) {
-        let survey_data_url = `/survey-data?schema_name=${schemaName}`
-        if (schemaUrl ){
-            survey_data_url += `&schema_url=${schemaUrl}`
+    async function loadCIRSchemas() {
+        let cir_url = `/collection-instrument-registry`
+        await getDataAsync(cir_url)
+            .then(cir_response => {
+                cirSchemas = cir_response.sort((a, b) => a.form_type < b.form_type ? -1 : 1)
+                document.querySelector("#cir-schemas").innerHTML += cirSchemas.map(schema =>
+                    `<option value="${schema.id}">${schema.form_type} (${schema.language})</option>`)
+                    .join("");
+            })
+            .catch(_ => {
+                document.querySelector("#cir-schemas").disabled = true
+            })
+    }
+
+    function loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId) {
+        let survey_data_url = `/survey-data?`
+
+        if (cirInstrumentId) {
+            survey_data_url += `&cir_instrument_id=${cirInstrumentId}`
+        }
+        else {
+            toggleCIRMetadata("hide");
+            if (schemaName)
+                survey_data_url += `&schema_name=${schemaName}`
+            if (schemaUrl)
+                survey_data_url += `&schema_url=${schemaUrl}`
         }
         toggleSupplementaryData("hide");
         getDataAsync(survey_data_url)
@@ -406,7 +490,6 @@
                 } else {
                     document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
                 }
-
                 toggleSubmitFlushButtons("show");
             })
             .catch(_ => {
@@ -456,34 +539,6 @@
         }
     }
 
-    function resetDropdowns() {
-        document.getElementById('launch_pattern').selectedIndex = -1;
-        document.getElementById('schema_name').selectedIndex = -1;
-        document.getElementById('schema-url-survey-type').selectedIndex = -1;
-    }
-
-    function retrieveSchemaName() {
-        const availableSchemas = [...document.querySelector("#schema_name").options].map(x => x.value)
-        let schemaName = localStorage.getItem("schema_name");
-        let localStorageButton = document.querySelector("#local-storage-btn")
-
-        if (schemaName && availableSchemas.includes(schemaName)) {
-            document.querySelector("#schema_name").value = schemaName;
-
-            toggleSubmitFlushButtons("show");
-            clearAndDisableSchemaUrlSelection();
-
-            const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType;
-
-            loadSurveyMetadata(schemaName, surveyType);
-            loadSchemaMetadata(schemaName, null);
-            localStorageButton.classList.remove("btn--hidden");
-        }
-        else {
-            localStorageButton.classList.add("btn--hidden");
-        }
-    }
-
     function retrieveResponseId() {
         let responseId = localStorage.getItem("response_id");
         let responseIdButton = document.querySelector("#response-id-btn");
@@ -507,13 +562,45 @@
     function clearLocalStorage() {
         localStorage.removeItem("response_id");
         localStorage.removeItem("schema_name");
+        localStorage.removeItem("survey_type");
+        localStorage.removeItem("cir_schema");
+        localStorage.removeItem("schema_url");
         location.reload();
     }
 
-    uuid('collection_exercise_sid');
-    uuid('case_id');
-    numericId();
-    setResponseExpiry();
+    function populateDropDownWithValue(selector, value) {
+        const availableOptions = [...document.querySelector(selector).options].map(x => x.value)
+
+        if (availableOptions.includes(value)) {
+            document.querySelector(selector).value = value;
+        }
+    }
+
+    async function onLoad() {
+        uuid('collection_exercise_sid');
+        uuid('case_id');
+        numericId();
+        setResponseExpiry();
+        retrieveResponseId();
+        await loadCIRSchemas();
+
+        if (schemaName = localStorage.getItem("schema_name")){
+            populateDropDownWithValue("#schema_name", schemaName)
+            loadMetadataForSchemaName();
+        }
+        else {
+            if(surveyType = localStorage.getItem("survey_type")) {
+                populateDropDownWithValue("#remote-schema-survey-type", surveyType)
+            }
+            if(cirSchema = localStorage.getItem("cir_schema")) {
+                populateDropDownWithValue("#cir-schemas", cirSchema)
+            }
+            if(schemaUrl = localStorage.getItem("schema_url")) {
+                document.querySelector("#schema-url").value = schemaUrl
+            }
+        }
+    }
+    
 
 </script>
 


### PR DESCRIPTION
### What is the context of this PR?
This PR adds support for launching surveys that have come from CIR. A new env var `CIR_API_BASE_URL` has been added just like the SDS one for the base url of the service. By default it is that of the mock CIR. The backend uses this to fetch all `ciMetadata` and populate a new dropdown in launcher for CIR schemas. Just like with Runner, if the service is down, launcher will continue to work, but not populate the dropdown.

On Selection of a CIR schema and survey type clicking `Load Schema` will fetch the schema from CIR and use it to populate the Survey Metadata. It will use the attributes of the option to populate CIR Metadata (version, title, description, etc.)

The existing approach to disabling fields has been removed in favour of clearing fields when switching the launch type. So that you can easily swap between CIR schemas, Schema URL and Schema Name without needing to empty local storage. Local storage saving has also been extended to save the cir schema or schema url so repeated testing via these options is easier.

### How to review
To test functionally, switch to the [Runner branch with support for CIR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/1246) and the [Mock CIR branch](https://github.com/ONSdigital/eq-runner-mock-cir/pull/1) of the mock repo

Run `make load-schemas` in both runner and the Mock CIR then start launcher. You should be see all the schemas in the CIR Schemas dropdown, with their names and language. Selecting and launching one should work, and the dump and submission endpoints should show that `cir_instrument_id` is being used instead of `schema_name` or `schema_url`

Check that the launcher UI works as expected when swapping between the different types of schema launches and when refreshing the page. Additionally, check it still works for normal schemas when CIR is down.
