### PR TITLE
Use stripped branch name for docker tag

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,7 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Tag
-        run: echo "TAG=${{ github.event.pull_request.head.ref }}" > $GITHUB_ENV
+        run: |
+          CLEAN_TAG=$(echo "${{ github.event.pull_request.head.ref  }}"  | tr / -)
+          echo "TAG=$CLEAN_TAG" >> $GITHUB_ENV
       - name: Build
         run: >
           docker build -t onsdigital/eq-questionnaire-launcher:$TAG


### PR DESCRIPTION
### What is the context of this PR?
Allow branch name that contain `/` to be used for docker tags by replacing it with `-`. This fixes docker pushes for Dependabot PRs.
See the pushed image: https://hub.docker.com/layers/onsdigital/eq-questionnaire-launcher/clean-branch_name-for-tag-1.0.0/images/sha256-70818b32a42b0b2dd9cd7af8c8b450f6b208f1079a806efe2a18cb1f82f727cf?context=explore

### How to review
Ensure the docker push job passes in Actions.