### PR TITLE
Fix url schema launch

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -214,11 +214,6 @@ func generateClaims(claimValues map[string][]string, launcherSchema surveys.Laun
 	if len(claimValues["form_type"]) > 0 && len(claimValues["eq_id"]) > 0 {
 		log.Println("Deleting schema name from claims")
 		delete(claims, "schema_name")
-	} else {
-		// When quicklaunching, schema_name will not be set, but launcherSchema will have the schema_name.
-		if len(claimValues["schema_name"]) == 0 && launcherSchema.Name != "" {
-			claims["schema_name"] = launcherSchema.Name
-		}
 	}
 
 	log.Printf("Using claims: %s", claims)
@@ -251,11 +246,6 @@ func generateClaimsV2(claimValues map[string][]string, launcherSchema surveys.La
 	}
 
 	getSurveyMetadataFromClaims(claimValues, data, claims, surveyMetadata)
-
-	// When quicklaunching, schema_name will not be set, but launcherSchema will have the schema_name.
-	if len(claimValues["schema_name"]) == 0 && launcherSchema.Name != "" {
-		claims["schema_name"] = launcherSchema.Name
-	}
 
 	log.Printf("Using claims: %s", claims)
 

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -214,6 +214,11 @@ func generateClaims(claimValues map[string][]string, launcherSchema surveys.Laun
 	if len(claimValues["form_type"]) > 0 && len(claimValues["eq_id"]) > 0 {
 		log.Println("Deleting schema name from claims")
 		delete(claims, "schema_name")
+	} else {
+		// When quicklaunching, schema_name will not be set, but launcherSchema will have the schema_name.
+		if len(claimValues["schema_name"]) == 0 && launcherSchema.Name != "" {
+			claims["schema_name"] = launcherSchema.Name
+		}
 	}
 
 	log.Printf("Using claims: %s", claims)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4,11 +4,20 @@ body {
     color: #222;
 }
 
-label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:200px; font-size:0.9rem; }
+label {
+    display:inline-block;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    width:200px;
+    font-size:0.9rem;
+}
 
 .field-container {
     margin: 0 0 0.2rem 0;
-    position: relative;
+}
+
+.field-container--inline {
+    display: inline-block;
 }
 
 .btn--hidden, .supplementary-data--hidden, .cir-metadata--hidden {
@@ -20,9 +29,9 @@ label { display:inline-block; font-weight: 600; margin-bottom: 0.25rem; width:20
 }
 
 .btn--small {
-    font-size: 0.9rem  !important;
-    padding:0.50rem 2rem  !important;
-    margin: 0.1rem  !important;
+    font-size: 0.9rem !important;
+    padding:0.50rem 2rem !important;
+    margin: 0.1rem !important;
 }
 
 input[type=text] {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -69,7 +69,7 @@ select:disabled {
     height:auto;
     display:block;
     position:absolute;
-    top: -1px;
+    top: -2px;
     right: 2px;
     cursor:pointer;
 }

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -281,8 +281,7 @@ func GetLauncherSchema(schemaName string, schemaUrl string, cirInstrumentId stri
 	if schemaUrl != "" {
 		log.Println("Getting schema by URL: " + schemaUrl)
 		launcherSchema = LauncherSchema{
-			URL:  schemaUrl,
-			Name: schemaName,
+			URL: schemaUrl,
 		}
 	} else if cirInstrumentId != "" {
 		log.Println("Searching for schema by CIR Instrument ID: " + cirInstrumentId)

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -281,7 +281,7 @@ func GetLauncherSchema(schemaName string, schemaUrl string, cirInstrumentId stri
 	if schemaUrl != "" {
 		log.Println("Getting schema by URL: " + schemaUrl)
 		launcherSchema = LauncherSchema{
-			URL: schemaUrl,
+			URL:  schemaUrl,
 			Name: schemaName,
 		}
 	} else if cirInstrumentId != "" {

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -282,6 +282,7 @@ func GetLauncherSchema(schemaName string, schemaUrl string, cirInstrumentId stri
 		log.Println("Getting schema by URL: " + schemaUrl)
 		launcherSchema = LauncherSchema{
 			URL: schemaUrl,
+			Name: schemaName,
 		}
 	} else if cirInstrumentId != "" {
 		log.Println("Searching for schema by CIR Instrument ID: " + cirInstrumentId)

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -2,604 +2,604 @@
 
 {{ define "body" }}
 
-<body onload="onLoad()">
-    <h1>Launch a survey</h1>
-    <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
+    <body onload="onLoad()">
+        <h1>Launch a survey</h1>
+        <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
 
-        <strong><u>Launch Pattern</u></strong>
-        <div class="field-container">
-            <label for="launch_pattern">Version</label>
-            <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); ">
-                <option value="v1">v1</option>
-                <option value="v2" selected="selected">v2</option>
-            </select>
-        </div>
-
-        <strong><u>Launch by Schema Name</u></strong>
-        <div class="field-container">
-            <label for="schema_name">Schemas</label>
-            <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); setLaunchType('name')">
-                <option selected disabled>Select Schema</option>
-
-                {{ range $surveyType, $schemasList := .Schemas }}
-                    <optgroup label="{{ $surveyType }} Surveys">
-                        {{ range $schema := $schemasList }}
-                            <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
-                        {{ end }}
-                    </optgroup>
-                {{ end }}
-            </select>
-        </div>
-
-        <p>----------</p>
-
-        <strong><u>Launch Remote Schemas</u></strong>
-        <div class="field-container">
-            <span class="field-container__span">
-                <label for="remote-schema-survey-type">Survey Type</label>
-                <select name="survey-types" id="remote-schema-survey-type" onchange="setSurveyType(this)">
-                    <option selected disabled>Select Survey Type</option>
-                    {{ range $surveyType, $schemasList := .Schemas }}
-                    <option value="{{ $surveyType }}">{{ $surveyType }}</option>
-                {{ end }}
+            <strong><u>Launch Pattern</u></strong>
+            <div class="field-container">
+                <label for="launch_pattern">Version</label>
+                <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); ">
+                    <option value="v1">v1</option>
+                    <option value="v2" selected="selected">v2</option>
                 </select>
-            </span>
-        </div>
+            </div>
 
-        <div class="field-container">
-            <span class="field-container__span">
-                <label for="schema-url">Schema URL</label>
-                <input id="schema-url" name="schema_url" type="text" class="qa-schema_url" onchange="setSchemaUrl(this)">
-            </span>
-        </div>
-
-        <div class="field-container">
-            <span class="field-container__span">
-                <label for="cir-schemas">CIR Schema</label>
-                <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
+            <strong><u>Launch by Schema Name</u></strong>
+            <div class="field-container">
+                <label for="schema_name">Schemas</label>
+                <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); setLaunchType('name')">
                     <option selected disabled>Select Schema</option>
-                    {{ range $cirSchema := .CirSchemas }}
-                    <option value="{{ $cirSchema.ID }}" 
-                        data-form-type="{{ $cirSchema.FormType }}" 
-                        data-version="{{ $cirSchema.CIVersion }}" 
-                        data-language="{{ $cirSchema.Language }}"
-                        data-title="{{ $cirSchema.Title }}"
-                        data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>
+
+                    {{ range $surveyType, $schemasList := .Schemas }}
+                        <optgroup label="{{ $surveyType }} Surveys">
+                            {{ range $schema := $schemasList }}
+                                <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
+                            {{ end }}
+                        </optgroup>
                     {{ end }}
                 </select>
-            </span>
-        </div>
-
-        <div class="field-container">
-            <input type="button" onClick="loadMetadataForRemoteSchema();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
-        </div>
-
-        <p>----------</p>
-
-        <div id="survey_metadata_fields">
-        </div>
-
-        <div class="cir-metadata cir-metadata--hidden">
-            <h3>CIR Metadata</h3>
-            <div id="cir_metadata">
             </div>
-        </div>
 
-        <h3>Survey Metadata</h3>
-        <div id="survey_metadata">
-            <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
-        </div>
+            <p>----------</p>
 
-        <div class="supplementary-data supplementary-data--hidden">
-            <h3>Supplementary Data</h3>
-            <div id="supplementary_data">
+            <strong><u>Launch Remote Schemas</u></strong>
+            <div class="field-container">
+                <span class="field-container__span">
+                    <label for="remote-schema-survey-type">Survey Type</label>
+                    <select name="survey-types" id="remote-schema-survey-type" onchange="setSurveyType(this)">
+                        <option selected disabled>Select Survey Type</option>
+                        {{ range $surveyType, $schemasList := .Schemas }}
+                        <option value="{{ $surveyType }}">{{ $surveyType }}</option>
+                    {{ end }}
+                    </select>
+                </span>
             </div>
-        </div>
 
-        <h3>Required Data</h3>
+            <div class="field-container">
+                <span class="field-container__span">
+                    <label for="schema-url">Schema URL</label>
+                    <input id="schema-url" name="schema_url" type="text" class="qa-schema_url" onchange="setSchemaUrl(this)">
+                </span>
+            </div>
 
-        <div class="field-container">
-            <label for="case_id">Case ID</label>
-            <span class="field-container__span">
-                <input id="case_id" name="case_id" type="text" class="qa-case_id">
-                <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-            </span>
-        </div>
+            <div class="field-container">
+                <span class="field-container__span">
+                    <label for="cir-schemas">CIR Schema</label>
+                    <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
+                        <option selected disabled>Select Schema</option>
+                        {{ range $cirSchema := .CirSchemas }}
+                        <option value="{{ $cirSchema.ID }}" 
+                            data-form-type="{{ $cirSchema.FormType }}" 
+                            data-version="{{ $cirSchema.CIVersion }}" 
+                            data-language="{{ $cirSchema.Language }}"
+                            data-title="{{ $cirSchema.Title }}"
+                            data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>
+                        {{ end }}
+                    </select>
+                </span>
+            </div>
 
-        <div class="field-container field-container--inline">
-            <label for="response_id">Response ID</label>
-            <span class="field-container__span">
-                <input id="response_id" name="response_id" type="text" class="qa-response_id">
-                <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-            </span>
-        </div>
-        <input type="button" value="Load Previous Value" class="btn--hidden" id="response-id-btn" onclick="loadResponseId()"/>
+            <div class="field-container">
+                <input type="button" onClick="loadMetadataForRemoteSchema();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
+            </div>
 
-        <div class="field-container">
-            <label for="collection_exercise_sid">Collection Exercise SID</label>
-            <span class="field-container__span">
-                <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
-                <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-            </span>
-        </div>
+            <p>----------</p>
 
-        <div class="field-container">
-            <label for="response_expires_at">Response Expiry Time</label>
-            <span class="field-container__span">
-                <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
-                <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-            </span>
-        </div>
+            <div id="survey_metadata_fields">
+            </div>
 
-
-        <h3>Runner Data</h3>
-        <div class="field-container">
-            <label for="exp">Token Expiry (seconds)</label>
-            <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
-        </div>
-
-        <div class="field-container">
-            <label for="language_code">Language</label>
-            <select id="language_code" name="language_code" class="qa-language-code">
-                <option value="en">English (en)</option>
-                <option value="cy">Cymraeg (cy)</option>
-                <option value="ga">Gaeilge (ga)</option>
-                <option value="eo">Ulstér Scotch (eo)</option>
-                <option value="">&lt;not set&gt;</option>
-            </select>
-        </div>
-
-        <div class="field-container">
-            <label for="roles">Roles</label>
-            <select id="roles" name="roles" multiple="multiple" class="qa-roles">
-                <option value="flusher">flusher</option>
-                <option value="dumper" selected>dumper</option>
-            </select>
-        </div>
-
-        <div class="field-container">
-            <label for="account_service_url">Account Service URL</label>
-            <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
-        </div>
-
-        <div class="field-container">
-            <label for="account_service_log_out_url">Account Service Log Out URL</label>
-            <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
-        </div>
-
-        <div class="field-container">
-            <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn" onclick="saveResponseId()"/>
-            <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
-            <input type="button" value="Clear Local Storage" class="qa-btn-submit-dev btn" id="local-storage-btn" onclick="clearLocalStorage()"/>
-        </div>
-
-    </form>
-</body>
-<script>
-    // uuidv4: from https://github.com/kelektiv/node-uuid
-    !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
-
-    // store fetch so it only needs to be re-done if the survey changes
-    let supplementaryDataSets = null;
-
-    function clearSurveyMetadataFields() {
-        document.querySelector('#survey_metadata_fields').innerHTML = ""
-        showSupplementaryData(false);
-    }
-
-    function setSurveyType(event) {
-        localStorage.setItem("survey_type", event.value)
-        setLaunchType("remote");
-    }
-
-    function setCirSchema(event) {
-        localStorage.setItem("cir_schema", event.value)
-        setLaunchType("cir");
-    }
-
-    function setSchemaUrl(event) {
-        localStorage.setItem("schema_url", event.value)
-        setLaunchType("url");
-    }
-
-    function setLaunchType(launchType) {
-        const schemaName = document.querySelector("#schema_name")
-        const schemaUrl = document.querySelector("#schema-url")
-        const cirSchemas = document.querySelector("#cir-schemas")
-        const remoteSchemaSurveyType = document.querySelector("#remote-schema-survey-type")
-
-        if(launchType === "cir" || launchType === "remote" || launchType === "url"){
-            if (schemaName.selectedIndex) {
-                clearSurveyMetadataFields();
-                showSubmitFlushButtons(false);
-                schemaName.selectedIndex = 0
-                localStorage.removeItem("schema_name")
-            }
-
-            if (launchType === "cir") {
-                schemaUrl.value = ""
-                localStorage.removeItem("schema_url")
-            }
-            else if (launchType === "url") {
-                cirSchemas.selectedIndex = 0
-                localStorage.removeItem("cir_schema")
-            }
-        }
-        if (launchType === "name") {
-            schemaUrl.value = ""
-            cirSchemas.selectedIndex = 0
-            remoteSchemaSurveyType.selectedIndex = 0
-            localStorage.removeItem("schema_url")
-            localStorage.removeItem("cir_schema")
-            localStorage.removeItem("survey_type")
-            document.querySelector("#language_code").disabled = false;
-        }
-    }
-
-    function showSupplementaryData(show) {
-        if (show) {
-            document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
-        }
-        else{
-            document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
-        }
-    }
-
-    function showCIRMetadata(show) {
-        if (show) {
-            document.querySelector(".cir-metadata").classList.remove("cir-metadata--hidden");
-        }
-        else {
-            document.querySelector(".cir-metadata").classList.add("cir-metadata--hidden");
-        }
-    }
-
-    function showSubmitFlushButtons(show, justSubmit = false) {
-        if (show) {
-            document.querySelector("#submit-btn").classList.remove("btn--hidden");
-            if (!justSubmit) {
-                document.querySelector("#flush-btn").classList.remove("btn--hidden");
-            }
-        } else {
-            document.querySelector("#submit-btn").classList.add("btn--hidden");
-            if (!justSubmit) {
-                document.querySelector("#flush-btn").classList.add("btn--hidden");
-            }
-        }
-    }
-
-    function includeSurveyMetadataFields(schema_name, survey_type) {
-        let launchPattern = document.querySelector("#launch_pattern").value
-        let eqIdValue = schema_name.split('_')[0]
-        let formTypeValue = schema_name.split("_").slice(1).join("_")
-
-        if (launchPattern === "v1") {
-            document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
-                <div class="field-container">
-                    <label for="eq_id">eq_id</label>
-                    <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
+            <div class="cir-metadata cir-metadata--hidden">
+                <h3>CIR Metadata</h3>
+                <div id="cir_metadata">
                 </div>
-                <div class="field-container">
-                    <label for="form_type">form_type</label>
-                    <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
-                </div>`
-        } else {
-            document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
-                <div class="field-container">
-                    <label for="form_type">form_type</label>
-                    <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
-                </div>`
+            </div>
+
+            <h3>Survey Metadata</h3>
+            <div id="survey_metadata">
+                <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
+            </div>
+
+            <div class="supplementary-data supplementary-data--hidden">
+                <h3>Supplementary Data</h3>
+                <div id="supplementary_data">
+                </div>
+            </div>
+
+            <h3>Required Data</h3>
+
+            <div class="field-container">
+                <label for="case_id">Case ID</label>
+                <span class="field-container__span">
+                    <input id="case_id" name="case_id" type="text" class="qa-case_id">
+                    <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
+
+            <div class="field-container field-container--inline">
+                <label for="response_id">Response ID</label>
+                <span class="field-container__span">
+                    <input id="response_id" name="response_id" type="text" class="qa-response_id">
+                    <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
+            <input type="button" value="Load Previous Value" class="btn--hidden" id="response-id-btn" onclick="loadResponseId()"/>
+
+            <div class="field-container">
+                <label for="collection_exercise_sid">Collection Exercise SID</label>
+                <span class="field-container__span">
+                    <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
+                    <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
+
+            <div class="field-container">
+                <label for="response_expires_at">Response Expiry Time</label>
+                <span class="field-container__span">
+                    <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
+                    <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+                </span>
+            </div>
+
+
+            <h3>Runner Data</h3>
+            <div class="field-container">
+                <label for="exp">Token Expiry (seconds)</label>
+                <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
+            </div>
+
+            <div class="field-container">
+                <label for="language_code">Language</label>
+                <select id="language_code" name="language_code" class="qa-language-code">
+                    <option value="en">English (en)</option>
+                    <option value="cy">Cymraeg (cy)</option>
+                    <option value="ga">Gaeilge (ga)</option>
+                    <option value="eo">Ulstér Scotch (eo)</option>
+                    <option value="">&lt;not set&gt;</option>
+                </select>
+            </div>
+
+            <div class="field-container">
+                <label for="roles">Roles</label>
+                <select id="roles" name="roles" multiple="multiple" class="qa-roles">
+                    <option value="flusher">flusher</option>
+                    <option value="dumper" selected>dumper</option>
+                </select>
+            </div>
+
+            <div class="field-container">
+                <label for="account_service_url">Account Service URL</label>
+                <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
+            </div>
+
+            <div class="field-container">
+                <label for="account_service_log_out_url">Account Service Log Out URL</label>
+                <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
+            </div>
+
+            <div class="field-container">
+                <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn" onclick="saveResponseId()"/>
+                <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
+                <input type="button" value="Clear Local Storage" class="qa-btn-submit-dev btn" id="local-storage-btn" onclick="clearLocalStorage()"/>
+            </div>
+
+        </form>
+    </body>
+    <script>
+        // uuidv4: from https://github.com/kelektiv/node-uuid
+        !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var n;n="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,n.uuidv4=e()}}(function(){return function e(n,r,o){function t(f,u){if(!r[f]){if(!n[f]){var a="function"==typeof require&&require;if(!u&&a)return a(f,!0);if(i)return i(f,!0);var d=new Error("Cannot find module '"+f+"'");throw d.code="MODULE_NOT_FOUND",d}var p=r[f]={exports:{}};n[f][0].call(p.exports,function(e){var r=n[f][1][e];return t(r?r:e)},p,p.exports,e,n,r,o)}return r[f].exports}for(var i="function"==typeof require&&require,f=0;f<o.length;f++)t(o[f]);return t}({1:[function(e,n,r){function o(e,n){var r=n||0,o=t;return[o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],"-",o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]],o[e[r++]]].join("")}for(var t=[],i=0;i<256;++i)t[i]=(i+256).toString(16).substr(1);n.exports=o},{}],2:[function(e,n,r){var o="undefined"!=typeof crypto&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto)||"undefined"!=typeof msCrypto&&"function"==typeof window.msCrypto.getRandomValues&&msCrypto.getRandomValues.bind(msCrypto);if(o){var t=new Uint8Array(16);n.exports=function(){return o(t),t}}else{var i=new Array(16);n.exports=function(){for(var e,n=0;n<16;n++)0===(3&n)&&(e=4294967296*Math.random()),i[n]=e>>>((3&n)<<3)&255;return i}}},{}],3:[function(e,n,r){function o(e,n,r){var o=n&&r||0;"string"==typeof e&&(n="binary"===e?new Array(16):null,e=null),e=e||{};var f=e.random||(e.rng||t)();if(f[6]=15&f[6]|64,f[8]=63&f[8]|128,n)for(var u=0;u<16;++u)n[o+u]=f[u];return n||i(f)}var t=e("./lib/rng"),i=e("./lib/bytesToUuid");n.exports=o},{"./lib/bytesToUuid":1,"./lib/rng":2}]},{},[3])(3)});
+
+        // store fetch so it only needs to be re-done if the survey changes
+        let supplementaryDataSets = null;
+
+        function clearSurveyMetadataFields() {
+            document.querySelector('#survey_metadata_fields').innerHTML = ""
+            showSupplementaryData(false);
         }
 
-        showSupplementaryData(true);
-        document.querySelector('#survey_metadata_fields').classList.remove("supplementary-data--hidden");
-
-    }
-
-    function loadMetadataForSchemaName() {
-        let schemaName = document.querySelector("#schema_name").value;
-        localStorage.setItem("schema_name", schemaName);
-
-        if (schemaName !== "Select Schema") {
-            const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType;
-            loadSurveyMetadata(schemaName, surveyType);
-            loadSchemaMetadata(schemaName, null);
-        }
-    }
-
-    function loadMetadataForRemoteSchema() {
-        let schemaUrl = document.querySelector("#schema-url").value
-        let surveyType = document.querySelector("#remote-schema-survey-type")
-
-        let cirSchemaDropdown = document.querySelector("#cir-schemas")
-        let cirInstrumentId = cirSchemaDropdown.selectedIndex ? cirSchemaDropdown.value : null
-
-        let schemaName = null
-
-        if (schemaUrl && !schemaUrl.endsWith(".json")) {
-            alert("Schema URL is not valid URL must end with '.json'")
-            return false
+        function setSurveyType(event) {
+            localStorage.setItem("survey_type", event.value)
+            setLaunchType("remote");
         }
 
-        if (!surveyType.selectedIndex) {
-            alert("Select a Survey Type.")
-            return false
+        function setCirSchema(event) {
+            localStorage.setItem("cir_schema", event.value)
+            setLaunchType("cir");
         }
 
-        if (!schemaUrl && !cirInstrumentId) {
-            alert("Enter a Schema URL or select a CIR Schema.")
-            return false
+        function setSchemaUrl(event) {
+            localStorage.setItem("schema_url", event.value)
+            setLaunchType("url");
         }
 
-        if (schemaUrl){
-            schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
-            document.querySelector("#language_code").disabled = false;
+        function setLaunchType(launchType) {
+            const schemaName = document.querySelector("#schema_name")
+            const schemaUrl = document.querySelector("#schema-url")
+            const cirSchemas = document.querySelector("#cir-schemas")
+            const remoteSchemaSurveyType = document.querySelector("#remote-schema-survey-type")
+
+            if(launchType === "cir" || launchType === "remote" || launchType === "url"){
+                if (schemaName.selectedIndex) {
+                    clearSurveyMetadataFields();
+                    showSubmitFlushButtons(false);
+                    schemaName.selectedIndex = 0
+                    localStorage.removeItem("schema_name")
+                }
+
+                if (launchType === "cir") {
+                    schemaUrl.value = ""
+                    localStorage.removeItem("schema_url")
+                }
+                else if (launchType === "url") {
+                    cirSchemas.selectedIndex = 0
+                    localStorage.removeItem("cir_schema")
+                }
+            }
+            if (launchType === "name") {
+                schemaUrl.value = ""
+                cirSchemas.selectedIndex = 0
+                remoteSchemaSurveyType.selectedIndex = 0
+                localStorage.removeItem("schema_url")
+                localStorage.removeItem("cir_schema")
+                localStorage.removeItem("survey_type")
+                document.querySelector("#language_code").disabled = false;
+            }
         }
-        else {
-            let cirSchema = cirSchemaDropdown.options[cirSchemaDropdown.selectedIndex]
-            schemaName = cirSchema.getAttribute("data-form-type")
-            let language = cirSchema.getAttribute("data-language")
 
-            showCIRMetdata(cirInstrumentId, cirSchema);
-
-            // cir schemas are for a specific language, so populate and disable choosing it
-            populateDropDownWithValue("#language_code", language)
-            document.querySelector("#language_code").disabled = true;
+        function showSupplementaryData(show) {
+            if (show) {
+                document.querySelector(".supplementary-data").classList.remove("supplementary-data--hidden");
+            }
+            else{
+                document.querySelector(".supplementary-data").classList.add("supplementary-data--hidden");
+            }
         }
 
-        loadSurveyMetadata(schemaName, surveyType.value)
-        loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId)
-        showSubmitFlushButtons(true);
-    }
-
-    function loadSurveyMetadata(schema_name, survey_type) {
-        if (survey_type.toLowerCase() === "test" || survey_type.toLowerCase() === "social") {
-            clearSurveyMetadataFields()
-        } else {
-            includeSurveyMetadataFields(schema_name, survey_type)
+        function showCIRMetadata(show) {
+            if (show) {
+                document.querySelector(".cir-metadata").classList.remove("cir-metadata--hidden");
+            }
+            else {
+                document.querySelector(".cir-metadata").classList.add("cir-metadata--hidden");
+            }
         }
-    }
 
-    async function getDataAsync(queryParam) {
-        return new Promise((resolve, reject) => {
-            let xhttp = new XMLHttpRequest();
-            xhttp.onreadystatechange = function() {
-                if (this.readyState === 4) {
-                    if (this.status === 200) {
-                        resolve(JSON.parse(this.responseText))
-                    } else {
-                        alert(`Request failed. ${this.responseText}`)
-                        reject(`Request failed. ${this.responseText}`)
+        function showSubmitFlushButtons(show, justSubmit = false) {
+            if (show) {
+                document.querySelector("#submit-btn").classList.remove("btn--hidden");
+                if (!justSubmit) {
+                    document.querySelector("#flush-btn").classList.remove("btn--hidden");
+                }
+            } else {
+                document.querySelector("#submit-btn").classList.add("btn--hidden");
+                if (!justSubmit) {
+                    document.querySelector("#flush-btn").classList.add("btn--hidden");
+                }
+            }
+        }
+
+        function includeSurveyMetadataFields(schema_name, survey_type) {
+            let launchPattern = document.querySelector("#launch_pattern").value
+            let eqIdValue = schema_name.split('_')[0]
+            let formTypeValue = schema_name.split("_").slice(1).join("_")
+
+            if (launchPattern === "v1") {
+                document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
+                    <div class="field-container">
+                        <label for="eq_id">eq_id</label>
+                        <input id="eq_id" name="eq_id" type="text" value="${eqIdValue}" class="qa-eq_id" >
+                    </div>
+                    <div class="field-container">
+                        <label for="form_type">form_type</label>
+                        <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                    </div>`
+            } else {
+                document.querySelector('#survey_metadata_fields').innerHTML = `<h3>${survey_type} Survey Metadata</h3>
+                    <div class="field-container">
+                        <label for="form_type">form_type</label>
+                        <input id="form_type" name="form_type" type="text" value="${formTypeValue}" class="qa-form_type">
+                    </div>`
+            }
+
+            showSupplementaryData(true);
+            document.querySelector('#survey_metadata_fields').classList.remove("supplementary-data--hidden");
+
+        }
+
+        function loadMetadataForSchemaName() {
+            let schemaName = document.querySelector("#schema_name").value;
+            localStorage.setItem("schema_name", schemaName);
+
+            if (schemaName !== "Select Schema") {
+                const surveyType = document.querySelector(`#schema_name option[value="${schemaName}"]`).dataset.surveyType;
+                loadSurveyMetadata(schemaName, surveyType);
+                loadSchemaMetadata(schemaName, null);
+            }
+        }
+
+        function loadMetadataForRemoteSchema() {
+            let schemaUrl = document.querySelector("#schema-url").value
+            let surveyType = document.querySelector("#remote-schema-survey-type")
+
+            let cirSchemaDropdown = document.querySelector("#cir-schemas")
+            let cirInstrumentId = cirSchemaDropdown.selectedIndex ? cirSchemaDropdown.value : null
+
+            let schemaName = null
+
+            if (schemaUrl && !schemaUrl.endsWith(".json")) {
+                alert("Schema URL is not valid URL must end with '.json'")
+                return false
+            }
+
+            if (!surveyType.selectedIndex) {
+                alert("Select a Survey Type.")
+                return false
+            }
+
+            if (!schemaUrl && !cirInstrumentId) {
+                alert("Enter a Schema URL or select a CIR Schema.")
+                return false
+            }
+
+            if (schemaUrl){
+                schemaName = schemaUrl.split("/").slice(-1)[0].split(".json")[0]
+                document.querySelector("#language_code").disabled = false;
+            }
+            else {
+                let cirSchema = cirSchemaDropdown.options[cirSchemaDropdown.selectedIndex]
+                schemaName = cirSchema.getAttribute("data-form-type")
+                let language = cirSchema.getAttribute("data-language")
+
+                showCIRMetdata(cirInstrumentId, cirSchema);
+
+                // cir schemas are for a specific language, so populate and disable choosing it
+                populateDropDownWithValue("#language_code", language)
+                document.querySelector("#language_code").disabled = true;
+            }
+
+            loadSurveyMetadata(schemaName, surveyType.value)
+            loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId)
+            showSubmitFlushButtons(true);
+        }
+
+        function loadSurveyMetadata(schema_name, survey_type) {
+            if (survey_type.toLowerCase() === "test" || survey_type.toLowerCase() === "social") {
+                clearSurveyMetadataFields()
+            } else {
+                includeSurveyMetadataFields(schema_name, survey_type)
+            }
+        }
+
+        async function getDataAsync(queryParam) {
+            return new Promise((resolve, reject) => {
+                let xhttp = new XMLHttpRequest();
+                xhttp.onreadystatechange = function() {
+                    if (this.readyState === 4) {
+                        if (this.status === 200) {
+                            resolve(JSON.parse(this.responseText))
+                        } else {
+                            alert(`Request failed. ${this.responseText}`)
+                            reject(`Request failed. ${this.responseText}`)
+                        }
                     }
-                }
-            };
-            xhttp.open("GET", queryParam, true);
-            xhttp.send();
-        })
-    }
-
-    function getLabelFor(fieldName){
-        return `<label for="${fieldName}">${fieldName}</label>`
-    }
-
-    function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
-        const value = defaultValue ? `value="${defaultValue}"` : ''
-        const readOnly = isReadOnly ? 'readonly' : ''
-        return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
-    }
-
-    async function loadSDSDatasetMetadata(survey_id, period_id) {
-        if (survey_id && period_id) {
-            const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
-            return await getDataAsync(sds_dataset_metadata_url)
+                };
+                xhttp.open("GET", queryParam, true);
+                xhttp.send();
+            })
         }
-        return null
-    }
 
-    function handleNoSupplementaryData() {
-        showSupplementaryData(false);
-        showSubmitFlushButtons(false);
-    }
-
-    function showCIRMetdata(cirInstrumentId, cirSchema) {
-        showCIRMetadata(true);
-        let ciMetadata = {
-            "id": cirInstrumentId,
-            "ci_version": cirSchema.getAttribute("data-version"),
-            "title": cirSchema.getAttribute("data-title"),
-            "description": cirSchema.getAttribute("data-description"),
+        function getLabelFor(fieldName){
+            return `<label for="${fieldName}">${fieldName}</label>`
         }
-        document.querySelector("#cir_metadata").innerHTML = Object.keys(ciMetadata).map(
-            key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", ciMetadata[key], true)}</div>`
-            ).join('')
-    }
 
-    function updateSDSDropdown() {
-        const surveyId = document.getElementById("survey_id")?.value;
-        const periodId = document.getElementById("period_id")?.value;
-        loadSDSDatasetMetadata(surveyId, periodId)
-            .then(sds_metadata_response => {
-                if (sds_metadata_response?.length) {
-                    supplementaryDataSets = sds_metadata_response
-                    showSupplementaryData(true);
-                    showSubmitFlushButtons(true);
-                    document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
-                        `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
-                        .join("");
-                    loadSupplementaryDataInfo();
-                } else if (document.querySelector("#sds_dataset_id")) {
-                    document.querySelector("#sds_dataset_id").innerHTML = "";
+        function getInputField(fieldName, type, defaultValue=null, isReadOnly=false, onChangeCallback=null){
+            const value = defaultValue ? `value="${defaultValue}"` : ''
+            const readOnly = isReadOnly ? 'readonly' : ''
+            return `<input ${readOnly} id="${fieldName}" name="${fieldName}" type="${type}" ${value} class="qa-${fieldName}" onchange="${onChangeCallback}">`
+        }
+
+        async function loadSDSDatasetMetadata(survey_id, period_id) {
+            if (survey_id && period_id) {
+                const sds_dataset_metadata_url = `/supplementary-data?survey_id=${survey_id}&period_id=${period_id}`
+                return await getDataAsync(sds_dataset_metadata_url)
+            }
+            return null
+        }
+
+        function handleNoSupplementaryData() {
+            showSupplementaryData(false);
+            showSubmitFlushButtons(false);
+        }
+
+        function showCIRMetdata(cirInstrumentId, cirSchema) {
+            showCIRMetadata(true);
+            let ciMetadata = {
+                "id": cirInstrumentId,
+                "ci_version": cirSchema.getAttribute("data-version"),
+                "title": cirSchema.getAttribute("data-title"),
+                "description": cirSchema.getAttribute("data-description"),
+            }
+            document.querySelector("#cir_metadata").innerHTML = Object.keys(ciMetadata).map(
+                key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", ciMetadata[key], true)}</div>`
+                ).join('')
+        }
+
+        function updateSDSDropdown() {
+            const surveyId = document.getElementById("survey_id")?.value;
+            const periodId = document.getElementById("period_id")?.value;
+            loadSDSDatasetMetadata(surveyId, periodId)
+                .then(sds_metadata_response => {
+                    if (sds_metadata_response?.length) {
+                        supplementaryDataSets = sds_metadata_response
+                        showSupplementaryData(true);
+                        showSubmitFlushButtons(true);
+                        document.querySelector("#sds_dataset_id").innerHTML = sds_metadata_response.map(dataset =>
+                            `<option value="${dataset.dataset_id}">${dataset.dataset_id}</option>`)
+                            .join("");
+                        loadSupplementaryDataInfo();
+                    } else if (document.querySelector("#sds_dataset_id")) {
+                        document.querySelector("#sds_dataset_id").innerHTML = "";
+                        handleNoSupplementaryData();
+                    }
+                })
+                .catch(_ => {
                     handleNoSupplementaryData();
+                })
+        }
+
+        function loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId) {
+            let survey_data_url = `/survey-data?`
+
+            if (cirInstrumentId) {
+                survey_data_url += `&cir_instrument_id=${cirInstrumentId}`
+            }
+            else {
+                showCIRMetadata(false);
+                if (schemaName)
+                    survey_data_url += `&schema_name=${schemaName}`
+                if (schemaUrl)
+                    survey_data_url += `&schema_url=${schemaUrl}`
+            }
+            showSupplementaryData(false);
+            getDataAsync(survey_data_url)
+                .then(schema_response => {
+                    document.querySelector("#survey_metadata").innerHTML = "";
+                    document.querySelector("#survey_metadata").innerHTML = "";
+
+                    if (schema_response.metadata.length > 0) {
+                        document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
+
+                            const fieldName = metadataField["name"]
+                            const defaultValue = metadataField['default'];
+
+                            return `<div class="field-container">${getLabelFor(fieldName)}${
+                                (() => {
+                                    if (metadataField['type'] === "boolean") {
+                                        return getInputField(fieldName, "checkbox");
+                                    }
+                                    else if (metadataField['type'] === "uuid") {
+                                        return (
+                                            `<span class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
+                                            `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
+                                            `</span>`
+                                        );
+                                    }
+                                    else if (fieldName === "survey_id" || fieldName === "period_id") {
+                                        return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
+                                    }
+                                    else if (fieldName === "sds_dataset_id") {
+                                        return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
+                                    }
+                                    else {
+                                        return getInputField(fieldName, "text", defaultValue)
+                                    }
+                                })()
+                            }</div>`
+                        }).join("")
+                        updateSDSDropdown()
+                    } else {
+                        document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                    }
+                    showSubmitFlushButtons(true);
+                })
+                .catch(_ => {
+                    document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
+                })
+        }
+
+        function loadSupplementaryDataInfo () {
+            const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
+            const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
+            if (selectedDataset) {
+                const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
+
+                document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
+                    key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
+                ).join('')
+            }
+        }
+
+        function uuid(el_id) {
+            document.querySelector(`#${el_id}`).value = uuidv4();
+        }
+
+        function numericId() {
+            let result = '';
+            let chars = '0123456789';
+            for (let i = 16; i > 0; --i) {
+                result += chars[Math.round(Math.random() * (chars.length - 1))];
+            }
+            document.querySelector(`#response_id`).value = result;
+        }
+
+        function setResponseExpiry(days_offset=7) {
+            let dt = new Date();
+            dt.setDate(dt.getDate()+days_offset)
+            document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
+        }
+
+        function validateForm() {
+            validateResponseExpiresAt();
+        }
+
+        function validateResponseExpiresAt() {
+            let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
+            if (isNaN(responseExpiresAt)) {
+                document.querySelector('#response_expires_at').remove()
+            }
+        }
+
+        function retrieveResponseId() {
+            let responseId = localStorage.getItem("response_id");
+            let responseIdButton = document.querySelector("#response-id-btn");
+
+            if (responseId) {
+                responseIdButton.classList.remove("btn--hidden");
+            }
+            else {
+                responseIdButton.classList.add("btn--hidden");
+            }
+        }
+
+        function loadResponseId() {
+            document.querySelector("#response_id").value = localStorage.getItem("response_id");
+        }
+
+        function saveResponseId() {
+            localStorage.setItem("response_id", document.querySelector("#response_id").value);
+        }
+
+        function clearLocalStorage() {
+            localStorage.removeItem("response_id");
+            localStorage.removeItem("schema_name");
+            localStorage.removeItem("survey_type");
+            localStorage.removeItem("cir_schema");
+            localStorage.removeItem("schema_url");
+            location.reload();
+        }
+
+        function populateDropDownWithValue(selector, value) {
+            const availableOptions = [...document.querySelector(selector).options].map(x => x.value)
+
+            if (availableOptions.includes(value)) {
+                document.querySelector(selector).value = value;
+            }
+        }
+
+        function onLoad() {
+            uuid('collection_exercise_sid');
+            uuid('case_id');
+            numericId();
+            setResponseExpiry();
+            retrieveResponseId();
+
+            if (schemaName = localStorage.getItem("schema_name")){
+                populateDropDownWithValue("#schema_name", schemaName)
+                loadMetadataForSchemaName();
+            }
+            else {
+                if(surveyType = localStorage.getItem("survey_type")) {
+                    populateDropDownWithValue("#remote-schema-survey-type", surveyType)
                 }
-            })
-            .catch(_ => {
-                handleNoSupplementaryData();
-            })
-    }
-
-    function loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId) {
-        let survey_data_url = `/survey-data?`
-
-        if (cirInstrumentId) {
-            survey_data_url += `&cir_instrument_id=${cirInstrumentId}`
-        }
-        else {
-            showCIRMetadata(false);
-            if (schemaName)
-                survey_data_url += `&schema_name=${schemaName}`
-            if (schemaUrl)
-                survey_data_url += `&schema_url=${schemaUrl}`
-        }
-        showSupplementaryData(false);
-        getDataAsync(survey_data_url)
-            .then(schema_response => {
-                document.querySelector("#survey_metadata").innerHTML = "";
-                document.querySelector("#survey_metadata").innerHTML = "";
-
-                if (schema_response.metadata.length > 0) {
-                    document.querySelector("#survey_metadata").innerHTML = schema_response.metadata.map(metadataField => {
-
-                        const fieldName = metadataField["name"]
-                        const defaultValue = metadataField['default'];
-
-                        return `<div class="field-container">${getLabelFor(fieldName)}${
-                            (() => {
-                                if (metadataField['type'] === "boolean") {
-                                    return getInputField(fieldName, "checkbox");
-                                }
-                                else if (metadataField['type'] === "uuid") {
-                                    return (
-                                        `<span class="field-container__span">${getInputField(fieldName, "text", uuidv4())}` +
-                                        `<img class="field-container__img" onclick="uuid('${fieldName}')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">` +
-                                        `</span>`
-                                    );
-                                }
-                                else if (fieldName === "survey_id" || fieldName === "period_id") {
-                                    return getInputField(fieldName, "text", fieldName === "survey_id" ? schema_response.survey_id : defaultValue, false, "updateSDSDropdown()");
-                                }
-                                else if (fieldName === "sds_dataset_id") {
-                                    return `<select id="${fieldName}" name="${fieldName}" class="qa-${fieldName}" onchange="loadSupplementaryDataInfo()"></select>`
-                                }
-                                else {
-                                    return getInputField(fieldName, "text", defaultValue)
-                                }
-                            })()
-                        }</div>`
-                    }).join("")
-                    updateSDSDropdown()
-                } else {
-                    document.querySelector("#survey_metadata").innerHTML = "No metadata required for this survey";
+                if(cirSchema = localStorage.getItem("cir_schema")) {
+                    populateDropDownWithValue("#cir-schemas", cirSchema)
                 }
-                showSubmitFlushButtons(true);
-            })
-            .catch(_ => {
-                document.querySelector("#survey_metadata").innerHTML = "Failed to load Survey Metadata";
-            })
-    }
-
-    function loadSupplementaryDataInfo () {
-        const selectedDatasetId = document.getElementById("sds_dataset_id")?.value;
-        const selectedDataset = supplementaryDataSets?.find(d => d["dataset_id"] === selectedDatasetId)
-        if (selectedDataset) {
-            const sdsDatasetMetadataKeys = ["title", "sds_schema_version", "total_reporting_units", "schema_version", "sds_dataset_version"];
-
-            document.querySelector("#supplementary_data").innerHTML = sdsDatasetMetadataKeys.map(
-                key => `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`
-            ).join('')
-        }
-    }
-
-    function uuid(el_id) {
-        document.querySelector(`#${el_id}`).value = uuidv4();
-    }
-
-    function numericId() {
-        let result = '';
-        let chars = '0123456789';
-        for (let i = 16; i > 0; --i) {
-            result += chars[Math.round(Math.random() * (chars.length - 1))];
-        }
-        document.querySelector(`#response_id`).value = result;
-    }
-
-    function setResponseExpiry(days_offset=7) {
-        let dt = new Date();
-        dt.setDate(dt.getDate()+days_offset)
-        document.querySelector('#response_expires_at').value=dt.toISOString().replace(/(\.\d*)/, '').replace(/Z/, '+00:00');
-    }
-
-    function validateForm() {
-        validateResponseExpiresAt();
-    }
-
-    function validateResponseExpiresAt() {
-        let responseExpiresAt = Date.parse(document.querySelector('#response_expires_at').value)
-        if (isNaN(responseExpiresAt)) {
-            document.querySelector('#response_expires_at').remove()
-        }
-    }
-
-    function retrieveResponseId() {
-        let responseId = localStorage.getItem("response_id");
-        let responseIdButton = document.querySelector("#response-id-btn");
-
-        if (responseId) {
-            responseIdButton.classList.remove("btn--hidden");
-        }
-        else {
-            responseIdButton.classList.add("btn--hidden");
-        }
-    }
-
-    function loadResponseId() {
-        document.querySelector("#response_id").value = localStorage.getItem("response_id");
-    }
-
-    function saveResponseId() {
-        localStorage.setItem("response_id", document.querySelector("#response_id").value);
-    }
-
-    function clearLocalStorage() {
-        localStorage.removeItem("response_id");
-        localStorage.removeItem("schema_name");
-        localStorage.removeItem("survey_type");
-        localStorage.removeItem("cir_schema");
-        localStorage.removeItem("schema_url");
-        location.reload();
-    }
-
-    function populateDropDownWithValue(selector, value) {
-        const availableOptions = [...document.querySelector(selector).options].map(x => x.value)
-
-        if (availableOptions.includes(value)) {
-            document.querySelector(selector).value = value;
-        }
-    }
-
-    function onLoad() {
-        uuid('collection_exercise_sid');
-        uuid('case_id');
-        numericId();
-        setResponseExpiry();
-        retrieveResponseId();
-
-        if (schemaName = localStorage.getItem("schema_name")){
-            populateDropDownWithValue("#schema_name", schemaName)
-            loadMetadataForSchemaName();
-        }
-        else {
-            if(surveyType = localStorage.getItem("survey_type")) {
-                populateDropDownWithValue("#remote-schema-survey-type", surveyType)
-            }
-            if(cirSchema = localStorage.getItem("cir_schema")) {
-                populateDropDownWithValue("#cir-schemas", cirSchema)
-            }
-            if(schemaUrl = localStorage.getItem("schema_url")) {
-                document.querySelector("#schema-url").value = schemaUrl
+                if(schemaUrl = localStorage.getItem("schema_url")) {
+                    document.querySelector("#schema-url").value = schemaUrl
+                }
             }
         }
-    }
 
-</script>
+    </script>
 
 {{ end }}

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -65,7 +65,7 @@
                             data-version="{{ $cirSchema.CIVersion }}" 
                             data-language="{{ $cirSchema.Language }}"
                             data-title="{{ $cirSchema.Title }}"
-                            data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>      
+                            data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>
                         {{ end }}
                     </select>
                 </span>
@@ -107,14 +107,14 @@
                 </span>
             </div>
 
-            <div class="field-container">
+            <div class="field-container field-container--inline">
                 <label for="response_id">Response ID</label>
                 <span class="field-container__span">
                     <input id="response_id" name="response_id" type="text" class="qa-response_id">
                     <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
                 </span>
-                <input type="button" value="Load Previous Value" class="btn--hidden" id="response-id-btn" onclick="loadResponseId()"/>
             </div>
+            <input type="button" value="Load Previous Value" class="btn--hidden" id="response-id-btn" onclick="loadResponseId()"/>
 
             <div class="field-container">
                 <label for="collection_exercise_sid">Collection Exercise SID</label>
@@ -215,16 +215,16 @@
                 clearSurveyMetadataFields();
                 showSubmitFlushButtons(false);
                 schemaName.selectedIndex = 0
-                localStorage.removeItem("schema_name")                
-            }                            
+                localStorage.removeItem("schema_name")
+            }
 
             if (launchType === "cir") {
-                schemaUrl.value = ""  
-                localStorage.removeItem("schema_url")              
+                schemaUrl.value = ""
+                localStorage.removeItem("schema_url")
             }
             else if (launchType === "url") {
                 cirSchemas.selectedIndex = 0
-                localStorage.removeItem("cir_schema")                
+                localStorage.removeItem("cir_schema")
             }
         }
         if (launchType === "name") {
@@ -234,7 +234,7 @@
             localStorage.removeItem("schema_url")
             localStorage.removeItem("cir_schema")
             localStorage.removeItem("survey_type")
-            document.querySelector("#language_code").disabled = false;            
+            document.querySelector("#language_code").disabled = false;
         }
     }
 
@@ -313,9 +313,9 @@
         let schemaUrl = document.querySelector("#schema-url").value
         let surveyType = document.querySelector("#remote-schema-survey-type")
 
-        let cirSchemaDropdown = document.querySelector("#cir-schemas")        
+        let cirSchemaDropdown = document.querySelector("#cir-schemas")
         let cirInstrumentId = cirSchemaDropdown.selectedIndex ? cirSchemaDropdown.value : null
-        
+
         let schemaName = null
 
         if (schemaUrl && !schemaUrl.endsWith(".json")) {
@@ -343,12 +343,12 @@
             let language = cirSchema.getAttribute("data-language")
 
             showCIRMetdata(cirInstrumentId, cirSchema);
-        
+
             // cir schemas are for a specific language, so populate and disable choosing it
             populateDropDownWithValue("#language_code", language)
             document.querySelector("#language_code").disabled = true;
         }
-        
+
         loadSurveyMetadata(schemaName, surveyType.value)
         loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId)
         showSubmitFlushButtons(true);
@@ -407,7 +407,7 @@
         showCIRMetadata(true);
         let ciMetadata = {
             "id": cirInstrumentId,
-            "ci_version": cirSchema.getAttribute("data-version"),            
+            "ci_version": cirSchema.getAttribute("data-version"),
             "title": cirSchema.getAttribute("data-title"),
             "description": cirSchema.getAttribute("data-description"),
         }
@@ -601,7 +601,6 @@
             }
         }
     }
-    
 
 </script>
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -4,178 +4,176 @@
 
 <body onload="onLoad()">
     <h1>Launch a survey</h1>
-    <div>
-        <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
+    <form action="" method="POST" xmlns="http://www.w3.org/1999/html" onsubmit="validateForm()">
 
-            <strong><u>Launch Pattern</u></strong>
-            <div class="field-container">
-                <label for="launch_pattern">Version</label>
-                <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); ">
-                    <option value="v1">v1</option>
-                    <option value="v2" selected="selected">v2</option>
-                </select>
-            </div>
+        <strong><u>Launch Pattern</u></strong>
+        <div class="field-container">
+            <label for="launch_pattern">Version</label>
+            <select id="launch_pattern" name="launch_version" class="qa-select-launch-version" onchange="loadMetadataForSchemaName(); ">
+                <option value="v1">v1</option>
+                <option value="v2" selected="selected">v2</option>
+            </select>
+        </div>
 
-            <strong><u>Launch by Schema Name</u></strong>
-            <div class="field-container">
-                <label for="schema_name">Schemas</label>
-                <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); setLaunchType('name')">
-                    <option selected disabled>Select Schema</option>
+        <strong><u>Launch by Schema Name</u></strong>
+        <div class="field-container">
+            <label for="schema_name">Schemas</label>
+            <select id="schema_name" name="schema_name" class="qa-select-schema" onchange="loadMetadataForSchemaName(); setLaunchType('name')">
+                <option selected disabled>Select Schema</option>
 
-                    {{ range $surveyType, $schemasList := .Schemas }}
-                        <optgroup label="{{ $surveyType }} Surveys">
-                            {{ range $schema := $schemasList }}
-                                <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
-                            {{ end }}
-                        </optgroup>
-                    {{ end }}
-                </select>
-            </div>
-
-            <p>----------</p>
-
-            <strong><u>Launch Remote Schemas</u></strong>
-            <div class="field-container">
-                <span class="field-container__span">
-                    <label for="remote-schema-survey-type">Survey Type</label>
-                    <select name="survey-types" id="remote-schema-survey-type" onchange="setSurveyType(this)">
-                        <option selected disabled>Select Survey Type</option>
-                        {{ range $surveyType, $schemasList := .Schemas }}
-                        <option value="{{ $surveyType }}">{{ $surveyType }}</option>
-                    {{ end }}
-                    </select>
-                </span>
-            </div>
-
-            <div class="field-container">
-                <span class="field-container__span">
-                    <label for="schema-url">Schema URL</label>
-                    <input id="schema-url" name="schema_url" type="text" class="qa-schema_url" onchange="setSchemaUrl(this)">
-                </span>
-            </div>
-
-            <div class="field-container">
-                <span class="field-container__span">
-                    <label for="cir-schemas">CIR Schema</label>
-                    <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
-                        <option selected disabled>Select Schema</option>
-                        {{ range $cirSchema := .CirSchemas }}
-                        <option value="{{ $cirSchema.ID }}" 
-                            data-form-type="{{ $cirSchema.FormType }}" 
-                            data-version="{{ $cirSchema.CIVersion }}" 
-                            data-language="{{ $cirSchema.Language }}"
-                            data-title="{{ $cirSchema.Title }}"
-                            data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>
+                {{ range $surveyType, $schemasList := .Schemas }}
+                    <optgroup label="{{ $surveyType }} Surveys">
+                        {{ range $schema := $schemasList }}
+                            <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
                         {{ end }}
-                    </select>
-                </span>
-            </div>
+                    </optgroup>
+                {{ end }}
+            </select>
+        </div>
 
-            <div class="field-container">
-                <input type="button" onClick="loadMetadataForRemoteSchema();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
-            </div>
+        <p>----------</p>
 
-            <p>----------</p>
-
-            <div id="survey_metadata_fields">
-            </div>
-
-            <div class="cir-metadata cir-metadata--hidden">
-                <h3>CIR Metadata</h3>
-                <div id="cir_metadata">
-                </div>
-            </div>
-
-            <h3>Survey Metadata</h3>
-            <div id="survey_metadata">
-                <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
-            </div>
-
-            <div class="supplementary-data supplementary-data--hidden">
-                <h3>Supplementary Data</h3>
-                <div id="supplementary_data">
-                </div>
-            </div>
-
-            <h3>Required Data</h3>
-
-            <div class="field-container">
-                <label for="case_id">Case ID</label>
-                <span class="field-container__span">
-                    <input id="case_id" name="case_id" type="text" class="qa-case_id">
-                    <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-            <div class="field-container field-container--inline">
-                <label for="response_id">Response ID</label>
-                <span class="field-container__span">
-                    <input id="response_id" name="response_id" type="text" class="qa-response_id">
-                    <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-            <input type="button" value="Load Previous Value" class="btn--hidden" id="response-id-btn" onclick="loadResponseId()"/>
-
-            <div class="field-container">
-                <label for="collection_exercise_sid">Collection Exercise SID</label>
-                <span class="field-container__span">
-                    <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
-                    <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-            <div class="field-container">
-                <label for="response_expires_at">Response Expiry Time</label>
-                <span class="field-container__span">
-                    <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
-                    <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
-                </span>
-            </div>
-
-
-            <h3>Runner Data</h3>
-            <div class="field-container">
-                <label for="exp">Token Expiry (seconds)</label>
-                <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
-            </div>
-
-            <div class="field-container">
-                <label for="language_code">Language</label>
-                <select id="language_code" name="language_code" class="qa-language-code">
-                    <option value="en">English (en)</option>
-                    <option value="cy">Cymraeg (cy)</option>
-                    <option value="ga">Gaeilge (ga)</option>
-                    <option value="eo">Ulstér Scotch (eo)</option>
-                    <option value="">&lt;not set&gt;</option>
+        <strong><u>Launch Remote Schemas</u></strong>
+        <div class="field-container">
+            <span class="field-container__span">
+                <label for="remote-schema-survey-type">Survey Type</label>
+                <select name="survey-types" id="remote-schema-survey-type" onchange="setSurveyType(this)">
+                    <option selected disabled>Select Survey Type</option>
+                    {{ range $surveyType, $schemasList := .Schemas }}
+                    <option value="{{ $surveyType }}">{{ $surveyType }}</option>
+                {{ end }}
                 </select>
-            </div>
+            </span>
+        </div>
 
-            <div class="field-container">
-                <label for="roles">Roles</label>
-                <select id="roles" name="roles" multiple="multiple" class="qa-roles">
-                    <option value="flusher">flusher</option>
-                    <option value="dumper" selected>dumper</option>
+        <div class="field-container">
+            <span class="field-container__span">
+                <label for="schema-url">Schema URL</label>
+                <input id="schema-url" name="schema_url" type="text" class="qa-schema_url" onchange="setSchemaUrl(this)">
+            </span>
+        </div>
+
+        <div class="field-container">
+            <span class="field-container__span">
+                <label for="cir-schemas">CIR Schema</label>
+                <select id="cir-schemas" name="cir_instrument_id" class="qa-cir_instrument_id" onchange="setCirSchema(this);">
+                    <option selected disabled>Select Schema</option>
+                    {{ range $cirSchema := .CirSchemas }}
+                    <option value="{{ $cirSchema.ID }}" 
+                        data-form-type="{{ $cirSchema.FormType }}" 
+                        data-version="{{ $cirSchema.CIVersion }}" 
+                        data-language="{{ $cirSchema.Language }}"
+                        data-title="{{ $cirSchema.Title }}"
+                        data-description="{{ $cirSchema.Description }}">{{ $cirSchema.FormType }} ({{ $cirSchema.Language }})</option>
+                    {{ end }}
                 </select>
-            </div>
+            </span>
+        </div>
 
-            <div class="field-container">
-                <label for="account_service_url">Account Service URL</label>
-                <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
-            </div>
+        <div class="field-container">
+            <input type="button" onClick="loadMetadataForRemoteSchema();" value="Load Schema" class="qa-btn-submit-dev btn btn--small" id="schema-url-btn"/>
+        </div>
 
-            <div class="field-container">
-                <label for="account_service_log_out_url">Account Service Log Out URL</label>
-                <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
-            </div>
+        <p>----------</p>
 
-            <div class="field-container">
-                <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn" onclick="saveResponseId()"/>
-                <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
-                <input type="button" value="Clear Local Storage" class="qa-btn-submit-dev btn" id="local-storage-btn" onclick="clearLocalStorage()"/>
-            </div>
+        <div id="survey_metadata_fields">
+        </div>
 
-        </form>
-    </div>
+        <div class="cir-metadata cir-metadata--hidden">
+            <h3>CIR Metadata</h3>
+            <div id="cir_metadata">
+            </div>
+        </div>
+
+        <h3>Survey Metadata</h3>
+        <div id="survey_metadata">
+            <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
+        </div>
+
+        <div class="supplementary-data supplementary-data--hidden">
+            <h3>Supplementary Data</h3>
+            <div id="supplementary_data">
+            </div>
+        </div>
+
+        <h3>Required Data</h3>
+
+        <div class="field-container">
+            <label for="case_id">Case ID</label>
+            <span class="field-container__span">
+                <input id="case_id" name="case_id" type="text" class="qa-case_id">
+                <img class="field-container__img" onclick="uuid('case_id')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+            </span>
+        </div>
+
+        <div class="field-container field-container--inline">
+            <label for="response_id">Response ID</label>
+            <span class="field-container__span">
+                <input id="response_id" name="response_id" type="text" class="qa-response_id">
+                <img class="field-container__img" onclick="numericId()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+            </span>
+        </div>
+        <input type="button" value="Load Previous Value" class="btn--hidden" id="response-id-btn" onclick="loadResponseId()"/>
+
+        <div class="field-container">
+            <label for="collection_exercise_sid">Collection Exercise SID</label>
+            <span class="field-container__span">
+                <input id="collection_exercise_sid" name="collection_exercise_sid" type="text" class="qa-collection-sid">
+                <img class="field-container__img" onclick="uuid('collection_exercise_sid')" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+            </span>
+        </div>
+
+        <div class="field-container">
+            <label for="response_expires_at">Response Expiry Time</label>
+            <span class="field-container__span">
+                <input id="response_expires_at" name="response_expires_at" type="text" class="qa-response-expires-at">
+                <img class="field-container__img" onclick="setResponseExpiry()" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg==">
+            </span>
+        </div>
+
+
+        <h3>Runner Data</h3>
+        <div class="field-container">
+            <label for="exp">Token Expiry (seconds)</label>
+            <input id="exp" name="exp" type="text" value="1800" class="qa-token-expiry">
+        </div>
+
+        <div class="field-container">
+            <label for="language_code">Language</label>
+            <select id="language_code" name="language_code" class="qa-language-code">
+                <option value="en">English (en)</option>
+                <option value="cy">Cymraeg (cy)</option>
+                <option value="ga">Gaeilge (ga)</option>
+                <option value="eo">Ulstér Scotch (eo)</option>
+                <option value="">&lt;not set&gt;</option>
+            </select>
+        </div>
+
+        <div class="field-container">
+            <label for="roles">Roles</label>
+            <select id="roles" name="roles" multiple="multiple" class="qa-roles">
+                <option value="flusher">flusher</option>
+                <option value="dumper" selected>dumper</option>
+            </select>
+        </div>
+
+        <div class="field-container">
+            <label for="account_service_url">Account Service URL</label>
+            <input id="account_service_url" name="account_service_url" type="text" value="{{.AccountServiceURL}}" class="qa-account_service_url">
+        </div>
+
+        <div class="field-container">
+            <label for="account_service_log_out_url">Account Service Log Out URL</label>
+            <input id="account_service_log_out_url" name="account_service_log_out_url" type="text" value="{{.AccountServiceLogOutURL}}" class="qa-account_service_log_out_url">
+        </div>
+
+        <div class="field-container">
+            <input type="submit" name="action_launch" value="Open Survey" class="qa-btn-submit-dev btn btn--hidden" id="submit-btn" onclick="saveResponseId()"/>
+            <input type="submit" name="action_flush" value="Flush Survey Data" class="qa-btn-submit-dev btn btn--hidden" id="flush-btn"/>
+            <input type="button" value="Clear Local Storage" class="qa-btn-submit-dev btn" id="local-storage-btn" onclick="clearLocalStorage()"/>
+        </div>
+
+    </form>
 </body>
 <script>
     // uuidv4: from https://github.com/kelektiv/node-uuid

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,6 +7,6 @@
             <title>{{ template "title" }}</title>
             <link rel="stylesheet" href="/static/css/main.css">
         </head>
-        {{ template "body" . }}
+        {{ template "body" }}
     </html>
 {{ end }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,6 +7,6 @@
             <title>{{ template "title" }}</title>
             <link rel="stylesheet" href="/static/css/main.css">
         </head>
-        {{ template "body" }}
+        {{ template "body" . }}
     </html>
 {{ end }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,12 +1,12 @@
-{{define "layout"}}
-<!doctype html>
-<html>
-    <head>
-        <meta charset="utf-8">
-        <meta content="width=device-width, initial-scale=1" name="viewport">
-        <title>{{template "title"}}</title>
-        <link rel="stylesheet" href="/static/css/main.css">
-    </head>
-    {{template "body" .}}
-</html>
-{{end}}
+{{ define "layout" }}
+    <!doctype html>
+    <html>
+        <head>
+            <meta charset="utf-8">
+            <meta content="width=device-width, initial-scale=1" name="viewport">
+            <title>{{ template "title" }}</title>
+            <link rel="stylesheet" href="/static/css/main.css">
+        </head>
+        {{ template "body" . }}
+    </html>
+{{ end }}


### PR DESCRIPTION
### What is the context of this PR?
This makes the change to only send the schema url to runner when launching via a schema url

Also fixes the alignment of the arrow icon next to the load previous value button and tidys up the code a bit.

### How to review
- Run this launcher branch locally, see that the arrow icon is now aligned
- Launch a schema from a url and see that the schema launches. This is a url you can use to test that: `https://raw.githubusercontent.com/ONSdigital/eq-questionnaire-schemas/main/schemas/business/en/1_0005.json`
- Use the quick launch facility to launch a schema and see that the schema launches correctly without error. This is a url you can use to test that: `http://localhost:8000/quick-launch?url=https://raw.githubusercontent.com/ONSdigital/eq-questionnaire-schemas/main/schemas/business/en/1_0005.json`