### PR TITLE
Display SDS dataset IDs either with survey metadata or in SDS section

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -173,6 +173,12 @@ func generateClaimsV2(claimValues map[string][]string, schema QuestionnaireSchem
 	claims["tx_id"] = TxID.String()
 	claims["version"] = "v2"
 
+	// always send survey_id for business/test surveys unless it's already in survey metadata
+	_, ok := claimValues["survey_id"]
+	if !ok && !isSocialSurvey(schema.SurveyType) {
+		claimValues["survey_id"] = []string{schema.SurveyId}
+	}
+
 	surveyMetadata := make(map[string]interface{})
 	data := make(map[string]interface{})
 

--- a/launch.go
+++ b/launch.go
@@ -168,7 +168,7 @@ func redirectURL(w http.ResponseWriter, r *http.Request) {
 	} else if launchVersion != "" {
 		http.Redirect(w, r, hostURL+"/session?token="+token, 301)
 	} else {
-		http.Error(w,"Invalid Action", 500)
+		http.Error(w, "Invalid Action", 500)
 	}
 }
 

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -139,6 +139,9 @@
 // store fetch so it only needs to be re-done if the survey changes
 let supplementaryDataSets = null;
 
+// We always need survey_id from top-level schema metadata for SDS retrieval
+let schemaSurveyId = null;
+
 function clearSurveyMetadataFields() {
   document.querySelector("#survey_metadata_fields").innerHTML = "";
   showSupplementaryData(false);
@@ -366,7 +369,6 @@ async function loadSDSDatasetMetadata(survey_id, period_id) {
 
 function handleNoSupplementaryData() {
   showSupplementaryData(false);
-  showSubmitFlushButtons(false);
 }
 
 function showCIRMetdata(cirInstrumentId, cirSchema) {
@@ -386,14 +388,31 @@ function showCIRMetdata(cirInstrumentId, cirSchema) {
 }
 
 function updateSDSDropdown() {
-  const surveyId = document.getElementById("survey_id")?.value;
+  const surveyId = schemaSurveyId;
   const periodId = document.getElementById("period_id")?.value;
+
+  const supplementaryDataSection = document.querySelector(
+    "#supplementary_data",
+  );
+  const sdsDatasetIdElement = document.querySelector("#sds_dataset_id");
+
   loadSDSDatasetMetadata(surveyId, periodId)
     .then((sds_metadata_response) => {
       if (sds_metadata_response?.length) {
+        document.querySelector("#supplementary_data").innerHTML = "";
         supplementaryDataSets = sds_metadata_response;
         showSupplementaryData(true);
         showSubmitFlushButtons(true);
+
+        if (
+          !document
+            .querySelector("#survey_metadata")
+            .contains(sdsDatasetIdElement)
+        ) {
+          // add sds_dataset_id field into the SDS metadata section if not already in survey metadata
+          supplementaryDataSection.innerHTML = `<div class="field-container">${getLabelFor("sds_dataset_id")}<select id="sds_dataset_id" name="sds_dataset_id" class="qa-sds_dataset_id" onchange="loadSupplementaryDataInfo()"></select></div>`;
+        }
+
         document.querySelector("#sds_dataset_id").innerHTML =
           sds_metadata_response
             .map(
@@ -427,6 +446,9 @@ function loadSchemaMetadata(schemaName, schemaUrl, cirInstrumentId) {
     .then((schema_response) => {
       document.querySelector("#survey_metadata").innerHTML = "";
       document.querySelector("#survey_metadata").innerHTML = "";
+
+      // We always need survey_id from top-level schema metadata for SDS retrieval
+      schemaSurveyId = schema_response.survey_id;
 
       if (schema_response.metadata.length > 0) {
         document.querySelector("#survey_metadata").innerHTML =
@@ -483,22 +505,30 @@ function loadSupplementaryDataInfo() {
   const selectedDataset = supplementaryDataSets?.find(
     (d) => d["dataset_id"] === selectedDatasetId,
   );
-  if (selectedDataset) {
-    const sdsDatasetMetadataKeys = [
-      "title",
-      "sds_schema_version",
-      "total_reporting_units",
-      "schema_version",
-      "sds_dataset_version",
-    ];
 
-    document.querySelector("#supplementary_data").innerHTML =
-      sdsDatasetMetadataKeys
-        .map(
-          (key) =>
-            `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`,
-        )
-        .join("");
+  if (!selectedDataset) {
+    return;
+  }
+
+  const sdsDatasetMetadataKeys = [
+    "title",
+    "total_reporting_units",
+    "schema_version",
+    "sds_dataset_version",
+  ];
+
+  const sdsMetadataSection = document.querySelector("#supplementary_data");
+  const sdsMetadataField = (key) =>
+    `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
+
+  if (sdsMetadataSection.contains(document.querySelector("#sds_dataset_id"))) {
+    sdsMetadataSection.innerHTML += sdsDatasetMetadataKeys
+      .map(sdsMetadataField)
+      .join("");
+  } else {
+    sdsMetadataSection.innerHTML = sdsDatasetMetadataKeys
+      .map(sdsMetadataField)
+      .join("");
   }
 }
 

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -369,6 +369,7 @@ async function loadSDSDatasetMetadata(survey_id, period_id) {
 
 function handleNoSupplementaryData() {
   showSupplementaryData(false);
+  showSubmitFlushButtons(false);
 }
 
 function showCIRMetdata(cirInstrumentId, cirSchema) {

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -44,7 +44,6 @@ type DatasetMetadata struct {
 	SurveyID            string `json:"survey_id"`
 	PeriodID            string `json:"period_id"`
 	Title               string `json:"title"`
-	SdsSchemaVersion    int    `json:"sds_schema_version"`
 	SdsPublishedAt      string `json:"sds_published_at"`
 	TotalReportingUnits int    `json:"total_reporting_units"`
 	SchemaVersion       string `json:"schema_version"`
@@ -253,6 +252,7 @@ func GetSupplementaryDataSets(surveyId string, periodId string) ([]DatasetMetada
 
 	log.Printf("SDS API Base URL: %s", hostURL)
 	url := fmt.Sprintf("%s/v1/dataset_metadata?survey_id=%s&period_id=%s", hostURL, surveyId, periodId)
+	log.Printf("Getting SDS metadata: %s", url)
 	resp, err := client.Get(url)
 
 	if err != nil || (resp.StatusCode != 200 && resp.StatusCode != 404) {

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -1,36 +1,41 @@
 {{ define "title" }}Launch a Survey{{ end }}
 {{ define "body" }}
 <body onload="onLoad()">
-<h1>Launch a survey</h1>
-<form action=""
-      method="post"
-      xmlns="http://www.w3.org/1999/html"
-      onsubmit="validateForm()">
-    <strong><u>Launch Pattern</u></strong>
-    <div class="field-container">
-        <label for="launch_pattern">Version</label>
-        <input id="launch_pattern" name="version" type="text" value="v2" class="qa-select-version" onload="loadMetadataForSchemaName();">
-    </div>
-    <strong><u>Launch by Schema Name</u></strong>
-    <div class="field-container">
-        <label for="schema_name">Schemas</label>
-        <select id="schema_name"
-                name="schema_name"
-                class="qa-select-schema"
-                onchange="loadMetadataForSchemaName(); setLaunchType('name')">
-            <option selected disabled>Select Schema</option>
-            {{ range $surveyType, $schemasList := .Schemas }}
-            <optgroup label="{{ $surveyType }} Surveys">
-                {{ range $schema := $schemasList }}
-                <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
+    <h1>Launch a survey</h1>
+    <form action=""
+          method="post"
+          xmlns="http://www.w3.org/1999/html"
+          onsubmit="validateForm()">
+        <strong><u>Launch Pattern</u></strong>
+        <div class="field-container">
+            <label for="launch_pattern">Version</label>
+            <input id="launch_pattern"
+                   name="version"
+                   type="text"
+                   value="v2"
+                   class="qa-select-version"
+                   onload="loadMetadataForSchemaName();">
+        </div>
+        <strong><u>Launch by Schema Name</u></strong>
+        <div class="field-container">
+            <label for="schema_name">Schemas</label>
+            <select id="schema_name"
+                    name="schema_name"
+                    class="qa-select-schema"
+                    onchange="loadMetadataForSchemaName(); setLaunchType('name')">
+                <option selected disabled>Select Schema</option>
+                {{ range $surveyType, $schemasList := .Schemas }}
+                <optgroup label="{{ $surveyType }} Surveys">
+                    {{ range $schema := $schemasList }}
+                    <option value="{{ $schema.Name }}" data-survey-type="{{ $surveyType }}">{{ $schema.Name }}</option>
+                    {{ end }}
+                </optgroup>
                 {{ end }}
-            </optgroup>
-            {{ end }}
-        </select>
-    </div>
-    <p>----------</p>
-    <strong><u>Launch Remote Schemas</u></strong>
-    <div class="field-container">
+            </select>
+        </div>
+        <p>----------</p>
+        <strong><u>Launch Remote Schemas</u></strong>
+        <div class="field-container">
             <span class="field-container__span">
                 <label for="remote-schema-survey-type">Survey Type</label>
                 <select name="survey-types"
@@ -42,8 +47,8 @@
                     {{ end }}
                 </select>
             </span>
-    </div>
-    <div class="field-container">
+        </div>
+        <div class="field-container">
             <span class="field-container__span">
                 <label for="schema-url">Schema URL</label>
                 <input id="schema-url"
@@ -52,8 +57,8 @@
                        class="qa-schema_url"
                        onchange="setSchemaUrl(this)">
             </span>
-    </div>
-    <div class="field-container">
+        </div>
+        <div class="field-container">
             <span class="field-container__span">
                 <label for="cir-schemas">CIR Schema</label>
                 <select id="cir-schemas"
@@ -73,42 +78,42 @@
                     {{ end }}
                 </select>
             </span>
-    </div>
-    <div class="field-container">
-        <input type="button"
-               onClick="loadMetadataForRemoteSchema();"
-               value="Load Schema"
-               class="qa-btn-submit-dev btn btn--small"
-               id="schema-url-btn" />
-    </div>
-    <p>----------</p>
-    <div id="survey_metadata_fields"></div>
-    <div class="cir-metadata cir-metadata--hidden">
-        <h3>CIR Metadata</h3>
-        <div id="cir_metadata"></div>
-    </div>
-    <h3>Survey Metadata</h3>
-    <div id="survey_metadata">
-        <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
-    </div>
-    <div class="supplementary-data supplementary-data--hidden">
-        <h3>Supplementary Data</h3>
-        <div id="supplementary_data"></div>
-    </div>
-    <h3>Required Data</h3>
-    <div class="field-container">
-        <label for="case_id">Case ID</label>
-        <span class="field-container__span">
+        </div>
+        <div class="field-container">
+            <input type="button"
+                   onClick="loadMetadataForRemoteSchema();"
+                   value="Load Schema"
+                   class="qa-btn-submit-dev btn btn--small"
+                   id="schema-url-btn" />
+        </div>
+        <p>----------</p>
+        <div id="survey_metadata_fields"></div>
+        <div class="cir-metadata cir-metadata--hidden">
+            <h3>CIR Metadata</h3>
+            <div id="cir_metadata"></div>
+        </div>
+        <h3>Survey Metadata</h3>
+        <div id="survey_metadata">
+            <p>--- Metadata fields will be loaded when you select a version and load a schema ---</p>
+        </div>
+        <div class="supplementary-data supplementary-data--hidden">
+            <h3>Supplementary Data</h3>
+            <div id="supplementary_data"></div>
+        </div>
+        <h3>Required Data</h3>
+        <div class="field-container">
+            <label for="case_id">Case ID</label>
+            <span class="field-container__span">
                 <input id="case_id" name="case_id" type="text" class="qa-case_id">
                 <img class="field-container__img"
                      onclick="uuid('case_id')"
                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg=="
                      alt="Reload symbol">
             </span>
-    </div>
-    <div class="field-container field-container--inline">
-        <label for="response_id">Response ID</label>
-        <span class="field-container__span">
+        </div>
+        <div class="field-container field-container--inline">
+            <label for="response_id">Response ID</label>
+            <span class="field-container__span">
                 <input id="response_id"
                        name="response_id"
                        type="text"
@@ -118,15 +123,15 @@
                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg=="
                      alt="Reload symbol">
             </span>
-    </div>
-    <input type="button"
-           value="Load Previous Value"
-           class="btn--hidden"
-           id="response-id-btn"
-           onclick="loadResponseId()" />
-    <div class="field-container">
-        <label for="collection_exercise_sid">Collection Exercise SID</label>
-        <span class="field-container__span">
+        </div>
+        <input type="button"
+               value="Load Previous Value"
+               class="btn--hidden"
+               id="response-id-btn"
+               onclick="loadResponseId()" />
+        <div class="field-container">
+            <label for="collection_exercise_sid">Collection Exercise SID</label>
+            <span class="field-container__span">
                 <input id="collection_exercise_sid"
                        name="collection_exercise_sid"
                        type="text"
@@ -136,10 +141,10 @@
                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg=="
                      alt="Reload symbol">
             </span>
-    </div>
-    <div class="field-container">
-        <label for="response_expires_at">Response Expiry Time</label>
-        <span class="field-container__span">
+        </div>
+        <div class="field-container">
+            <label for="response_expires_at">Response Expiry Time</label>
+            <span class="field-container__span">
                 <input id="response_expires_at"
                        name="response_expires_at"
                        type="text"
@@ -149,61 +154,61 @@
                      src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjwhRE9DVFlQRSBzdmcgIFBVQkxJQyAnLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4nICAnaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkJz48c3ZnIGhlaWdodD0iNTEycHgiIGlkPSJMYXllcl8xIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgdmVyc2lvbj0iMS4xIiB2aWV3Qm94PSIwIDAgNTEyIDUxMiIgd2lkdGg9IjUxMnB4IiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48Zz48cGF0aCBkPSJNMjU2LDM4NC4xYy03MC43LDAtMTI4LTU3LjMtMTI4LTEyOC4xYzAtNzAuOCw1Ny4zLTEyOC4xLDEyOC0xMjguMVY4NGw5Niw2NGwtOTYsNTUuN3YtNTUuOCAgIGMtNTkuNiwwLTEwOC4xLDQ4LjUtMTA4LjEsMTA4LjFjMCw1OS42LDQ4LjUsMTA4LjEsMTA4LjEsMTA4LjFTMzY0LjEsMzE2LDM2NC4xLDI1NkgzODRDMzg0LDMyNywzMjYuNywzODQuMSwyNTYsMzg0LjF6Ii8+PC9nPjwvc3ZnPg=="
                      alt="Reload symbol">
             </span>
-    </div>
-    <h3>Runner Data</h3>
-    <div class="field-container">
-        <label for="exp">Token Expiry (seconds)</label>
-        <input id="exp" type="text" value="1800" class="qa-token-expiry">
-    </div>
-    <div class="field-container">
-        <label for="language_code">Language</label>
-        <select id="language_code" name="language_code" class="qa-language-code">
-            <option value="en">English (en)</option>
-            <option value="cy">Cymraeg (cy)</option>
-            <option value="ga">Gaeilge (ga)</option>
-            <option value="eo">Ulstér Scotch (eo)</option>
-            <option value="">&lt;not set&gt;</option>
-        </select>
-    </div>
-    <div class="field-container">
-        <label for="roles">Roles</label>
-        <select id="roles" name="roles" multiple="multiple" class="qa-roles">
-            <option value="flusher">flusher</option>
-            <option value="dumper" selected>dumper</option>
-        </select>
-    </div>
-    <div class="field-container">
-        <label for="account_service_url">Account Service URL</label>
-        <input id="account_service_url"
-               name="account_service_url"
-               type="text"
-               value="{{.AccountServiceURL}}"
-               class="qa-account_service_url">
-    </div>
-    <div class="field-container">
-        <label for="account_service_log_out_url">Account Service Log Out URL</label>
-        <input id="account_service_log_out_url"
-               type="text"
-               value="{{.AccountServiceLogOutURL}}"
-               class="qa-account_service_log_out_url">
-    </div>
-    <div class="field-container">
-        <input type="submit"
-               value="Open Survey"
-               class="qa-btn-submit-dev btn btn--hidden"
-               id="submit-btn"
-               onclick="saveResponseId()" />
-        <input type="submit"
-               value="Flush Survey Data"
-               class="qa-btn-submit-dev btn btn--hidden"
-               id="flush-btn" />
-        <input type="button"
-               value="Clear Local Storage"
-               class="qa-btn-submit-dev btn"
-               id="local-storage-btn"
-               onclick="clearLocalStorage()" />
-    </div>
-</form>
-<script src="../static/javascript/launch.js"></script>
+        </div>
+        <h3>Runner Data</h3>
+        <div class="field-container">
+            <label for="exp">Token Expiry (seconds)</label>
+            <input id="exp" type="text" value="1800" class="qa-token-expiry">
+        </div>
+        <div class="field-container">
+            <label for="language_code">Language</label>
+            <select id="language_code" name="language_code" class="qa-language-code">
+                <option value="en">English (en)</option>
+                <option value="cy">Cymraeg (cy)</option>
+                <option value="ga">Gaeilge (ga)</option>
+                <option value="eo">Ulstér Scotch (eo)</option>
+                <option value="">&lt;not set&gt;</option>
+            </select>
+        </div>
+        <div class="field-container">
+            <label for="roles">Roles</label>
+            <select id="roles" name="roles" multiple="multiple" class="qa-roles">
+                <option value="flusher">flusher</option>
+                <option value="dumper" selected>dumper</option>
+            </select>
+        </div>
+        <div class="field-container">
+            <label for="account_service_url">Account Service URL</label>
+            <input id="account_service_url"
+                   name="account_service_url"
+                   type="text"
+                   value="{{.AccountServiceURL}}"
+                   class="qa-account_service_url">
+        </div>
+        <div class="field-container">
+            <label for="account_service_log_out_url">Account Service Log Out URL</label>
+            <input id="account_service_log_out_url"
+                   type="text"
+                   value="{{.AccountServiceLogOutURL}}"
+                   class="qa-account_service_log_out_url">
+        </div>
+        <div class="field-container">
+            <input type="submit"
+                   value="Open Survey"
+                   class="qa-btn-submit-dev btn btn--hidden"
+                   id="submit-btn"
+                   onclick="saveResponseId()" />
+            <input type="submit"
+                   value="Flush Survey Data"
+                   class="qa-btn-submit-dev btn btn--hidden"
+                   id="flush-btn" />
+            <input type="button"
+                   value="Clear Local Storage"
+                   class="qa-btn-submit-dev btn"
+                   id="local-storage-btn"
+                   onclick="clearLocalStorage()" />
+        </div>
+    </form>
+    <script src="../static/javascript/launch.js"></script>
 </body>
 {{ end }}


### PR DESCRIPTION
### What is the context of this PR?
To allow launching of business prepop surveys, our Launcher service needs to be altered to handle:

* Displaying of SDS `dataset_id` either in survey metadata (if present) or in the SDS section
* Sending the `survey_id` to Runner if it's a business survey only if the `survey_id` is not present in the survey metadata

### How to review
Run with the Mock SDS branch. Ensure that all relevant prepop surveys launch correctly and display the prepop data in Runner.

There might be other launch scenarios that I've missed, so would be grateful for any advice if so

Jira: https://jira.ons.gov.uk/browse/ECI-1122
