### PR TITLE
Update launcher to support multiple schema versions

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4,6 +4,7 @@ body {
   margin-left: 20px;
   margin-top: 15px;
   margin-right: 20px;
+  height: auto;
 }
 
 label {

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -142,6 +142,10 @@ let supplementaryDataSets = null;
 // We always need survey_id from top-level schema metadata for SDS retrieval
 let schemaSurveyId = null;
 
+const supplementaryDataSection = document.querySelector(
+    "#supplementary_data",
+);
+
 function clearSurveyMetadataFields() {
   document
     .querySelector("#survey-type-metadata-accordion")
@@ -398,10 +402,6 @@ function showCIRMetdata(cirInstrumentId, cirSchema) {
 function updateSDSDropdown() {
   const surveyId = schemaSurveyId;
   const periodId = document.getElementById("period_id")?.value;
-
-  const supplementaryDataSection = document.querySelector(
-    "#supplementary_data",
-  );
   const sdsDatasetIdElement = document.querySelector("#sds_dataset_id");
   loadSDSDatasetMetadata(surveyId, periodId)
     .then((sds_metadata_response) => {
@@ -527,31 +527,16 @@ function loadSupplementaryDataInfo() {
     "sds_dataset_version",
   ];
 
-  const sdsMetadataSection = document.querySelector("#supplementary_data");
   const sdsMetadataField = (key) =>
     `<div class="ons-field ons-field--inline" data-sds-metadata-key>${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
 
-  clearSDSMetadata();
-  if (sdsMetadataSection.contains(document.querySelector("#sds_dataset_id"))) {
-    sdsMetadataSection.innerHTML += sdsDatasetMetadataKeys
+  const supplementaryDataFields = document.createRange().createContextualFragment(sdsDatasetMetadataKeys
       .map(sdsMetadataField)
-      .join("");
-  } else {
-    sdsMetadataSection.innerHTML = sdsDatasetMetadataKeys
-      .map(sdsMetadataField)
-      .join("");
-  }
+      .join(""));
+  supplementaryDataSection.querySelectorAll(".ons-field[data-sds-metadata-key]").forEach(sds_value => sds_value.remove());
+  supplementaryDataSection.appendChild(supplementaryDataFields);
 }
 
-function clearSDSMetadata() {
-  let sds_values = document.querySelectorAll("#supplementary_data > div");
-  let sds_data = [...sds_values];
-  for (let i = 0; i < sds_data.length; i++) {
-    if (sds_data[i].hasAttribute("data-sds-metadata-key")) {
-      sds_data[i].remove();
-    }
-  }
-}
 
 function uuid(el_id) {
   document.querySelector(`#${el_id}`).value = uuidv4();

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -393,14 +393,14 @@ function updateSDSDropdown() {
   const periodId = document.getElementById("period_id")?.value;
 
   const supplementaryDataSection = document.querySelector(
-    "#supplementary_data",
+    "#sds_id",
   );
   const sdsDatasetIdElement = document.querySelector("#sds_dataset_id");
 
   loadSDSDatasetMetadata(surveyId, periodId)
     .then((sds_metadata_response) => {
       if (sds_metadata_response?.length) {
-        document.querySelector("#supplementary_data").innerHTML = "";
+        document.querySelector("#sds_id").innerHTML = "";
         supplementaryDataSets = sds_metadata_response;
         showSupplementaryData(true);
         showSubmitFlushButtons(true);
@@ -518,10 +518,14 @@ function loadSupplementaryDataInfo() {
     "sds_dataset_version",
   ];
 
-  const sdsMetadataSection = document.querySelector("#supplementary_data");
-  const sdsMetadataField = (key) =>
-    `<div class="field-container">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
+  // Since the sdsMetadataSection refers to the whole thing, it overwrites the change to the select and sets it back to the original
+  // I need to put them into 2 divs and then update the second one
 
+  const sdsMetadataSection = document.querySelector("#sds_data");
+  const sdsMetadataField = (key) =>
+    `<div class="field-container sds-data">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
+
+  clearSDSMetadata();
   if (sdsMetadataSection.contains(document.querySelector("#sds_dataset_id"))) {
     sdsMetadataSection.innerHTML += sdsDatasetMetadataKeys
       .map(sdsMetadataField)
@@ -530,6 +534,16 @@ function loadSupplementaryDataInfo() {
     sdsMetadataSection.innerHTML = sdsDatasetMetadataKeys
       .map(sdsMetadataField)
       .join("");
+  }
+}
+
+function clearSDSMetadata() {
+  let dataset = document.querySelectorAll("#sds_data > div");
+  let div_array = [...dataset];
+  for (let i = 0; i < div_array.length; i++) {
+    if ((div_array[i].classList.contains("sds-data"))) {
+      div_array[i].remove();
+    }
   }
 }
 

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -142,9 +142,7 @@ let supplementaryDataSets = null;
 // We always need survey_id from top-level schema metadata for SDS retrieval
 let schemaSurveyId = null;
 
-const supplementaryDataSection = document.querySelector(
-    "#supplementary_data",
-);
+const supplementaryDataSection = document.querySelector("#supplementary_data");
 
 function clearSurveyMetadataFields() {
   document
@@ -530,13 +528,16 @@ function loadSupplementaryDataInfo() {
   const sdsMetadataField = (key) =>
     `<div class="ons-field ons-field--inline" data-sds-metadata-key>${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
 
-  const supplementaryDataFields = document.createRange().createContextualFragment(sdsDatasetMetadataKeys
-      .map(sdsMetadataField)
-      .join(""));
-  supplementaryDataSection.querySelectorAll(".ons-field[data-sds-metadata-key]").forEach(sds_value => sds_value.remove());
+  const supplementaryDataFields = document
+    .createRange()
+    .createContextualFragment(
+      sdsDatasetMetadataKeys.map(sdsMetadataField).join(""),
+    );
+  supplementaryDataSection
+    .querySelectorAll(".ons-field[data-sds-metadata-key]")
+    .forEach((sds_value) => sds_value.remove());
   supplementaryDataSection.appendChild(supplementaryDataFields);
 }
-
 
 function uuid(el_id) {
   document.querySelector(`#${el_id}`).value = uuidv4();

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -399,7 +399,9 @@ function updateSDSDropdown() {
   const surveyId = schemaSurveyId;
   const periodId = document.getElementById("period_id")?.value;
 
-  const supplementaryDataSection = document.querySelector("#supplementary_data");
+  const supplementaryDataSection = document.querySelector(
+    "#supplementary_data",
+  );
   const sdsDatasetIdElement = document.querySelector("#sds_dataset_id");
   loadSDSDatasetMetadata(surveyId, periodId)
     .then((sds_metadata_response) => {

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -392,9 +392,7 @@ function updateSDSDropdown() {
   const surveyId = schemaSurveyId;
   const periodId = document.getElementById("period_id")?.value;
 
-  const supplementaryDataSection = document.querySelector(
-    "#sds_id",
-  );
+  const supplementaryDataSection = document.querySelector("#sds_id");
   const sdsDatasetIdElement = document.querySelector("#sds_dataset_id");
 
   loadSDSDatasetMetadata(surveyId, periodId)
@@ -541,7 +539,7 @@ function clearSDSMetadata() {
   let dataset = document.querySelectorAll("#sds_data > div");
   let div_array = [...dataset];
   for (let i = 0; i < div_array.length; i++) {
-    if ((div_array[i].classList.contains("sds-data"))) {
+    if (div_array[i].classList.contains("sds-data")) {
       div_array[i].remove();
     }
   }

--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -399,12 +399,12 @@ function updateSDSDropdown() {
   const surveyId = schemaSurveyId;
   const periodId = document.getElementById("period_id")?.value;
 
-  const supplementaryDataSection = document.querySelector("#sds_id");
+  const supplementaryDataSection = document.querySelector("#supplementary_data");
   const sdsDatasetIdElement = document.querySelector("#sds_dataset_id");
   loadSDSDatasetMetadata(surveyId, periodId)
     .then((sds_metadata_response) => {
       if (sds_metadata_response?.length) {
-        document.querySelector("#sds_id").innerHTML = "";
+        document.querySelector("#supplementary_data").innerHTML = "";
         supplementaryDataSets = sds_metadata_response;
         showMetadataAccordion("sds", true);
         setTabIndex("sds_metadata_detail", 0);
@@ -525,9 +525,9 @@ function loadSupplementaryDataInfo() {
     "sds_dataset_version",
   ];
 
-  const sdsMetadataSection = document.querySelector("#sds_data");
+  const sdsMetadataSection = document.querySelector("#supplementary_data");
   const sdsMetadataField = (key) =>
-    `<div class="ons-field ons-field--inline sds_data">${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
+    `<div class="ons-field ons-field--inline" data-sds-metadata-key>${getLabelFor(key)}${getInputField(key, "text", selectedDataset[key], true)}</div>`;
 
   clearSDSMetadata();
   if (sdsMetadataSection.contains(document.querySelector("#sds_dataset_id"))) {
@@ -542,11 +542,11 @@ function loadSupplementaryDataInfo() {
 }
 
 function clearSDSMetadata() {
-  let dataset = document.querySelectorAll("#sds_data > div");
-  let div_array = [...dataset];
-  for (let i = 0; i < div_array.length; i++) {
-    if (div_array[i].classList.contains("sds-data")) {
-      div_array[i].remove();
+  let sds_values = document.querySelectorAll("#supplementary_data > div");
+  let sds_data = [...sds_values];
+  for (let i = 0; i < sds_data.length; i++) {
+    if (sds_data[i].hasAttribute("data-sds-metadata-key")) {
+      sds_data[i].remove();
     }
   }
 }

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -221,9 +221,7 @@
                         </div>
                         <div id="sds-metadata-accordion-content"
                              class="ons-details__content ons-js-details-content ons-u-mb-m">
-                            <div class="supplementary-data">
-                                <div id="supplementary_data"></div>
-                            </div>
+                            <div id="supplementary_data"></div>
                         </div>
                     </div>
                     <div id="required-metadata-accordion"

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -224,7 +224,7 @@
                              class="ons-details__content ons-js-details-content ons-u-mb-m">
                             <div class="supplementary-data">
                                 <div id="supplementary_data">
-                                    <div id="sds_id"></div>
+                                    <div id="sds_id" class="ons-u-mb-m"></div>
                                     <div id="sds_data"></div>
                                 </div>
                             </div>

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -9,7 +9,7 @@
             <div class="ons-grid__col ons-col-6@xl">
                 <div class="ons-pl-grid-col">
                     <h1 class="ons-u-fs-xxl">Launch a survey</h1>
-                    <hr class="ons-u-mb-m">
+                    <hr class="ons-u-mb-xs">
                     <h2 class="ons-u-fs-m">Launch Pattern:</h2>
                     <div class="ons-field ons-field--inline">
                         <label class="ons-label" for="launch_pattern">Version</label>
@@ -20,7 +20,7 @@
                             <option value="v2" selected>v2</option>
                         </select>
                     </div>
-                    <hr class="ons-u-mb-m">
+                    <hr class="ons-u-mb-xs">
                     <h2 class="ons-u-mt-s ons-u-fs-m">Launch by Schema Name:</h2>
                     <div class="ons-field ons-field--inline">
                         <label class="ons-label" for="schema_name">Schemas</label>
@@ -38,7 +38,7 @@
                             {{ end }}
                         </select>
                     </div>
-                    <hr class="ons-u-mb-m">
+                    <hr class="ons-u-mb-xs">
                     <h2 class="ons-u-mt-s ons-u-fs-m">Launch Remote Schemas:</h2>
                     <div class="ons-field ons-field--inline">
                         <label class="ons-label" for="remote-schema-survey-type">Survey Type</label>
@@ -87,7 +87,7 @@
                             <span class="ons-btn__inner"><span class="ons-btn__text">Load Metadata</span></span>
                         </button>
                     </div>
-                    <hr>
+                    <hr class="ons-u-mb-xs">
                     <h2 class="ons-u-mt-m">Survey Actions</h2>
                     <div class="ons-btn-group">
                         <button id="submit-btn"

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -9,8 +9,8 @@
             <div class="ons-grid__col ons-col-6@xl">
                 <div class="ons-pl-grid-col">
                     <h1 class="ons-u-fs-xxl">Launch a survey</h1>
-                    <hr class="ons-u-mb-xs">
-                    <h2 class="ons-u-fs-m">Launch Pattern:</h2>
+                    <hr>
+                    <h2 class="ons-u-mt-s ons-u-fs-m">Launch Pattern:</h2>
                     <div class="ons-field ons-field--inline">
                         <label class="ons-label" for="launch_pattern">Version</label>
                         <select id="launch_pattern"
@@ -20,7 +20,7 @@
                             <option value="v2" selected>v2</option>
                         </select>
                     </div>
-                    <hr class="ons-u-mb-xs">
+                    <hr>
                     <h2 class="ons-u-mt-s ons-u-fs-m">Launch by Schema Name:</h2>
                     <div class="ons-field ons-field--inline">
                         <label class="ons-label" for="schema_name">Schemas</label>
@@ -38,7 +38,7 @@
                             {{ end }}
                         </select>
                     </div>
-                    <hr class="ons-u-mb-xs">
+                    <hr>
                     <h2 class="ons-u-mt-s ons-u-fs-m">Launch Remote Schemas:</h2>
                     <div class="ons-field ons-field--inline">
                         <label class="ons-label" for="remote-schema-survey-type">Survey Type</label>
@@ -87,8 +87,7 @@
                             <span class="ons-btn__inner"><span class="ons-btn__text">Load Metadata</span></span>
                         </button>
                     </div>
-                    <hr class="ons-u-mb-xs">
-                    <h2 class="ons-u-mt-m">Survey Actions</h2>
+                    <hr class="ons-u-mb-m">
                     <div class="ons-btn-group">
                         <button id="submit-btn"
                                 type="submit"

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -223,10 +223,7 @@
                         <div id="sds-metadata-accordion-content"
                              class="ons-details__content ons-js-details-content ons-u-mb-m">
                             <div class="supplementary-data">
-                                <div id="supplementary_data">
-                                    <div id="sds_id" class="ons-u-mb-m"></div>
-                                    <div id="sds_data"></div>
-                                </div>
+                                <div id="supplementary_data"></div>
                             </div>
                         </div>
                     </div>

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -98,7 +98,10 @@
         </div>
         <div class="supplementary-data supplementary-data--hidden">
             <h3>Supplementary Data</h3>
-            <div id="supplementary_data"></div>
+            <div id="supplementary_data">
+                <div id="sds_id"></div>
+                <div id="sds_data"></div>
+            </div>
         </div>
         <h3>Required Data</h3>
         <div class="field-container">


### PR DESCRIPTION
### What is the context of this PR?

Given the `schema_version` now has multiple versions, Launcher needed to be updated to support this where the data would update dynamically when choosing a different `sds_dataset_id`. Previously, when changing versions, it would add the dataset keys to the existing ones resulting in repeated fields. The changes made to the JS and HTML prevents that from occurring.

Ensure you use the Mock SDS [PR](https://github.com/ONSdigital/eq-runner-mock-sds/pull/19) when reviewing this to get the multiple schema versions for Supplementary Data. Make sure you use the Runner [PR](https://github.com/ONSdigital/eq-questionnaire-runner/pull/1414) too, to ensure that you can open schemas with multiple versions.

### How to review
- Ensure the changes make sense
- Ensure you can open schemas
- Ensure you select a different `sds_dataset_id` and the fields update correctly.
