### PR TITLE
Fix issue where the launch survey button being was disabled incorrectly

### DIFF
--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -376,7 +376,6 @@ async function loadSDSDatasetMetadata(survey_id, period_id) {
 function handleNoSupplementaryData() {
   showMetadataAccordion("sds", false);
   setTabIndex("sds_metadata_detail", -1);
-  enableSubmitFlushButtons(false);
 }
 
 function showCIRMetdata(cirInstrumentId, cirSchema) {


### PR DESCRIPTION
### What is the context of this PR?

The launch survey button being was disabled incorrectly when launching a supplementary data schema, then going back to launcher and opening a non supplementary data schema. This was due to an unnecessary call to the enableSubmitFlushButtons function when the handleNoSupplementaryData function was being called.

### How to review
Check that you are able to open a supplementary data schema, then launch a non supplementary data schema. Check no other scenarios are broken.
