### PR TITLE
Re-align Launcher with Mock CIR

### DIFF
--- a/static/javascript/launch.js
+++ b/static/javascript/launch.js
@@ -332,7 +332,7 @@ function loadMetadataForRemoteSchema() {
     document.querySelector("#language_code").disabled = false;
   } else {
     let cirSchema = cirSchemaDropdown.options[cirSchemaDropdown.selectedIndex];
-    schemaName = cirSchema.getAttribute("data-form-type");
+    schemaName = cirSchema.getAttribute("data-schema-name");
     let language = cirSchema.getAttribute("data-language");
 
     showCIRMetadata(cirInstrumentId, cirSchema);
@@ -414,10 +414,10 @@ function handleNoSupplementaryData() {
 function showCIRMetadata(cirInstrumentId, cirSchema) {
   showMetadataAccordion("cir", true);
   let ciMetadata = {
-    id: cirInstrumentId,
+    guid: cirInstrumentId,
     ci_version: cirSchema.getAttribute("data-version"),
     title: cirSchema.getAttribute("data-title"),
-    description: cirSchema.getAttribute("data-description"),
+    validator_version: cirSchema.getAttribute("data-validator-version"),
   };
   document.querySelector("#cir_metadata").innerHTML = Object.keys(ciMetadata)
     .map(

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -34,7 +34,7 @@ type CIMetadata struct {
 	PublishedAt      string `json:"published_at"`
 	SurveyID         string `json:"survey_id"`
 	Title            string `json:"title"`
-	SchemaName       string `json:"schema_name"`
+	SchemaName       string `json:"dev_schema_name"`
 	SDSSchema        string `json:"sds_schema"`
 }
 

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -24,18 +24,18 @@ type LauncherSchema struct {
 }
 
 type CIMetadata struct {
-	CIVersion     int    `json:"ci_version"`
-	DataVersion   string `json:"data_version"`
-	FormType      string `json:"form_type"`
-	ID            string `json:"id"`
-	Language      string `json:"language"`
-	PublishedAt   string `json:"published_at"`
-	SchemaVersion string `json:"schema_version"`
-	Status        string `json:"status"`
-	SurveyID      string `json:"survey_id"`
-	Title         string `json:"title"`
-	Description   string `json:"description"`
-	SDSSchema     string `json:"sds_schema"`
+	CIVersion        int    `json:"ci_version"`
+	DataVersion      string `json:"data_version"`
+	ValidatorVersion string `json:"validator_version"`
+	ClassifierType   string `json:"classifier_type"`
+	ClassifierValue  string `json:"classifier_value"`
+	GUID             string `json:"guid"`
+	Language         string `json:"language"`
+	PublishedAt      string `json:"published_at"`
+	SurveyID         string `json:"survey_id"`
+	Title            string `json:"title"`
+	SchemaName       string `json:"schema_name"`
+	SDSSchema        string `json:"sds_schema"`
 }
 
 type DatasetMetadata struct {
@@ -171,8 +171,7 @@ func GetAvailableSchemasFromCIR() []CIMetadata {
 		return ciMetadataList
 	}
 	// Easier to navigate schemas in alphabetical order
-	sort.Slice(ciMetadataList, func(i, j int) bool { return ciMetadataList[i].FormType < ciMetadataList[j].FormType })
-
+	sort.Slice(ciMetadataList, func(i, j int) bool { return ciMetadataList[i].SchemaName < ciMetadataList[j].SchemaName })
 	return ciMetadataList
 }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -70,6 +70,7 @@
                             {{ range $cirSchema := .CirSchemas }}
                             <option value="{{ $cirSchema.GUID }}"
                                     data-schema-name="{{ $cirSchema.SchemaName }}"
+                                    data-form-type="{{ $cirSchema.ClassifierValue }}"
                                     data-version="{{ $cirSchema.CIVersion }}"
                                     data-language="{{ $cirSchema.Language }}"
                                     data-title="{{ $cirSchema.Title }}"

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -68,13 +68,13 @@
                                 onchange="setCirSchema(this);">
                             <option selected disabled>Select Schema</option>
                             {{ range $cirSchema := .CirSchemas }}
-                            <option value="{{ $cirSchema.ID }}"
-                                    data-form-type="{{ $cirSchema.FormType }}"
+                            <option value="{{ $cirSchema.GUID }}"
+                                    data-schema-name="{{ $cirSchema.SchemaName }}"
                                     data-version="{{ $cirSchema.CIVersion }}"
                                     data-language="{{ $cirSchema.Language }}"
                                     data-title="{{ $cirSchema.Title }}"
-                                    data-description="{{ $cirSchema.Description }}">
-                                {{ $cirSchema.FormType }} ({{ $cirSchema.Language }})
+                                    data-validator-version="{{ $cirSchema.ValidatorVersion }}">
+                                {{ $cirSchema.SchemaName }} ({{ $cirSchema.Language }})
                             </option>
                             {{ end }}
                         </select>


### PR DESCRIPTION
### What is the context of this PR?
This adds changes from this mock CIR PR: https://github.com/ONSdigital/eq-runner-mock-cir/pull/23.

- New `data-schema-name` field is added to the relevant html block.
- Validator version now replaces "description" input field.
- "Id" displayed on the page was changed to "Guid".
- FormType field is now divided into `ClassifierType` and `ClassifierValue` to align with CIR.

`Form Type` field in Business/Health metadata block displayed as an input in Launcher is still derived from schema name. This is intentional as the form type is always identical to the last part of the schema name that is loaded, `loadSurveyMetadata` that has schema_name as an attribute is used in multiple places for different purposes, so the below logic was kept:
```javascript
let formTypeValue = schema_name.split("_").slice(1).join("_");
```

### How to review
Confirm that Launcher can still load the CIR metadata, load a survey, displays all the fields, works as expected.
