### PR TITLE
EQS-762: Add Launcher changes for non-mocked CIR

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -2,16 +2,15 @@ package main // import "github.com/ONSdigital/eq-questionnaire-launcher"
 
 import (
 	"fmt"
-	"time"
-
+	"html"
 	"html/template"
 	"log"
 	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"html"
+	"strings"
+	"time"
 
 	"github.com/ONSdigital/eq-questionnaire-launcher/authentication"
 	"github.com/ONSdigital/eq-questionnaire-launcher/settings"
@@ -43,7 +42,12 @@ func serveTemplate(templateName string, data interface{}, w http.ResponseWriter,
 		return
 	}
 
-	tmpl, err := template.ParseFiles(lp, fp)
+	// Register custom template functions
+	tmpl := template.New("layout.html").Funcs(template.FuncMap{
+		"HasPrefix": strings.HasPrefix,
+	})
+
+	tmpl, err = tmpl.ParseFiles(lp, fp)
 	if err != nil {
 		log.Println(err.Error())
 		http.Error(w, http.StatusText(500), 500)

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"sort"
+	"strings"
 
 	"github.com/AreaHQ/jsonhal"
 	"github.com/ONSdigital/eq-questionnaire-launcher/clients"
@@ -170,8 +171,27 @@ func GetAvailableSchemasFromCIR() []CIMetadata {
 		log.Print(err)
 		return ciMetadataList
 	}
-	// Easier to navigate schemas in order (survey id)
+
+	// Sort all schemas by survey_id to ensure test schemas are grouped together and appear after business schemas
+	// Supplementary data test schemas being exception as their id is "123" not "999"
 	sort.Slice(ciMetadataList, func(i, j int) bool { return ciMetadataList[i].SurveyID < ciMetadataList[j].SurveyID })
+	slice := 0
+	for i := range ciMetadataList {
+		if strings.Contains(ciMetadataList[i].Title, "Test") && ciMetadataList[i].SurveyID != "123" {
+			slice = i
+			break
+		}
+	}
+
+	// Split the list into test and business schemas
+	ciMetadataListSlice := ciMetadataList[0:slice]
+	ciTestMetadataListSlice := ciMetadataList[slice:]
+
+	// Sort test schemas alphabetically
+	sort.Slice(ciTestMetadataListSlice, func(i, j int) bool { return ciTestMetadataListSlice[i].Title < ciTestMetadataListSlice[j].Title })
+
+	// Finally join the list back together with business schemas appearing before test schemas
+	ciMetadataList = append(ciMetadataListSlice, ciTestMetadataListSlice...)
 	return ciMetadataList
 }
 

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -4,15 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"sort"
+
 	"github.com/AreaHQ/jsonhal"
 	"github.com/ONSdigital/eq-questionnaire-launcher/clients"
 	"github.com/ONSdigital/eq-questionnaire-launcher/oidc"
 	"github.com/ONSdigital/eq-questionnaire-launcher/settings"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"io"
-	"log"
-	"sort"
 )
 
 // LauncherSchema is a representation of a schema in the Launcher
@@ -34,7 +35,6 @@ type CIMetadata struct {
 	PublishedAt      string `json:"published_at"`
 	SurveyID         string `json:"survey_id"`
 	Title            string `json:"title"`
-	SchemaName       string `json:"dev_schema_name"`
 	SDSSchema        string `json:"sds_schema"`
 }
 
@@ -170,8 +170,8 @@ func GetAvailableSchemasFromCIR() []CIMetadata {
 		log.Print(err)
 		return ciMetadataList
 	}
-	// Easier to navigate schemas in alphabetical order
-	sort.Slice(ciMetadataList, func(i, j int) bool { return ciMetadataList[i].SchemaName < ciMetadataList[j].SchemaName })
+	// Easier to navigate schemas in order (survey id)
+	sort.Slice(ciMetadataList, func(i, j int) bool { return ciMetadataList[i].SurveyID < ciMetadataList[j].SurveyID })
 	return ciMetadataList
 }
 

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -69,13 +69,17 @@
                             <option selected disabled>Select Schema</option>
                             {{ range $cirSchema := .CirSchemas }}
                             <option value="{{ $cirSchema.GUID }}"
-                                    data-schema-name="{{ $cirSchema.SchemaName }}"
+                                    data-schema-name="{{ $cirSchema.Title }}"
                                     data-form-type="{{ $cirSchema.ClassifierValue }}"
                                     data-version="{{ $cirSchema.CIVersion }}"
                                     data-language="{{ $cirSchema.Language }}"
                                     data-title="{{ $cirSchema.Title }}"
                                     data-validator-version="{{ $cirSchema.ValidatorVersion }}">
-                                {{ $cirSchema.SchemaName }} ({{ $cirSchema.Language }})
+                                {{ if HasPrefix $cirSchema.Title "Test" }}
+                                    schema_title: {{ $cirSchema.Title}}
+                                {{ else }}
+                                    survey_id: {{ $cirSchema.SurveyID }} form_type: {{ $cirSchema.ClassifierValue }} ci_version: {{ $cirSchema.CIVersion }}
+                                {{ end }}
                             </option>
                             {{ end }}
                         </select>

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -76,7 +76,7 @@
                                     data-title="{{ $cirSchema.Title }}"
                                     data-validator-version="{{ $cirSchema.ValidatorVersion }}">
                                 {{ if HasPrefix $cirSchema.Title "Test" }}
-                                    schema_title: {{ $cirSchema.Title}}
+                                    schema_title: {{ $cirSchema.Title }}
                                 {{ else }}
                                     survey_id: {{ $cirSchema.SurveyID }} form_type: {{ $cirSchema.ClassifierValue }} ci_version: {{ $cirSchema.CIVersion }}
                                 {{ end }}


### PR DESCRIPTION
### What is the context of this PR?

This adds support for both mocked CIs and authentic CIs. It was agreed that test schemas will be displayed using `schema_title: {title}` format and business schemas using `survey_id: {id} form_type: {type} ci_version: {version}` format.
- Adds "sort by survey ID" logic
- Changes to how dropdown displays surveys
- Adds logic for test surveys
- Makes use of title metadata field instead of dev schema name

### How to review
To test: 
- copy schemas from Runner branch (https://github.com/ONSdigital/eq-questionnaire-runner/pull/1874) into Mock CIR schemas
- run local Mock CIR with these schemas in schema folder copied over
- open using this branch of local Launcher
