### PR TITLE
EQS-875: Update CIR endpoint names

### DIFF
--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -584,7 +584,7 @@ func getSchema(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, stri
 		hostURL := settings.Get("CIR_API_BASE_URL")
 
 		log.Println("Collection Instrument ID: ", launcherSchema.CIRInstrumentID)
-		url = fmt.Sprintf("%s/v2/retrieve_collection_instrument?guid=%s", hostURL, launcherSchema.CIRInstrumentID)
+		url = fmt.Sprintf("%s/collection-instrument/schema?guid=%s", hostURL, launcherSchema.CIRInstrumentID)
 
 		_, err := oidc.ConfigureClientAuthentication(client, "CIR_OAUTH2_CLIENT_ID")
 		if err != nil {

--- a/authentication/auth.go
+++ b/authentication/auth.go
@@ -584,7 +584,7 @@ func getSchema(launcherSchema surveys.LauncherSchema) (QuestionnaireSchema, stri
 		hostURL := settings.Get("CIR_API_BASE_URL")
 
 		log.Println("Collection Instrument ID: ", launcherSchema.CIRInstrumentID)
-		url = fmt.Sprintf("%s/collection-instrument/schema?guid=%s", hostURL, launcherSchema.CIRInstrumentID)
+		url = fmt.Sprintf("%s/collection-instruments/schema?guid=%s", hostURL, launcherSchema.CIRInstrumentID)
 
 		_, err := oidc.ConfigureClientAuthentication(client, "CIR_OAUTH2_CLIENT_ID")
 		if err != nil {

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -152,7 +152,7 @@ func GetAvailableSchemasFromCIR() []CIMetadata {
 	}
 
 	log.Printf("CIR API Base URL: %s", hostURL)
-	url := fmt.Sprintf("%s/collection-instrument/metadata", hostURL)
+	url := fmt.Sprintf("%s/collection-instruments/metadata", hostURL)
 
 	resp, err := client.Get(url)
 	if err != nil || resp.StatusCode != 200 {

--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -152,7 +152,7 @@ func GetAvailableSchemasFromCIR() []CIMetadata {
 	}
 
 	log.Printf("CIR API Base URL: %s", hostURL)
-	url := fmt.Sprintf("%s/v2/ci_metadata", hostURL)
+	url := fmt.Sprintf("%s/collection-instrument/metadata", hostURL)
 
 	resp, err := client.Get(url)
 	if err != nil || resp.StatusCode != 200 {


### PR DESCRIPTION
### What is the context of this PR?
CIR has updated its endpoint names to better conform to the REST API naming conventions. We update our cir endpoints to use their new endpoint.

### How to review
- start mock cir, runner and launcher with the new cir endpoint name
- confirm metadata is available via localhost..../collection-instruments/metadata
- open launcher select cir schema, load metadata, then open the survery
- confirm selected cir schema launches in runner