### PR TITLE
EQS-1008: Update SDS dataset metadata endpoint

### DIFF
--- a/surveys/surveys.go
+++ b/surveys/surveys.go
@@ -263,7 +263,7 @@ func GetSupplementaryDataSets(surveyId string, periodId string) ([]DatasetMetada
 	}
 
 	log.Printf("SDS API Base URL: %s", hostURL)
-	url := fmt.Sprintf("%s/v1/dataset_metadata?survey_id=%s&period_id=%s", hostURL, surveyId, periodId)
+	url := fmt.Sprintf("%s/datasets/metadata?survey_id=%s&period_id=%s", hostURL, surveyId, periodId)
 	log.Printf("Getting SDS metadata: %s", url)
 	resp, err := client.Get(url)
 


### PR DESCRIPTION
### What is the context of this PR?
Updates Launcher to call the new SDS dataset metadata endpoint.

- dataset endpoint name change remove v1 path and becomes /datasets/metadata

### How to review

- Run Runner, mock SDS and Launcher locally from their relevant branches, then launch a supplementary data survey through Launcher.
- For local testing, make sure Docker is only being used for supporting services such as Redis, Datastore and CIR.
- The Docker `sds` and `eq-questionnaire-launcher` containers should not be running, otherwise you may test against the old published images instead of the local branch changes.
- Confirmed Launcher calls the new SDS metadata endpoint and a supplementary data survey launches successfully.